### PR TITLE
feat: add canvas eraser

### DIFF
--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -1,47 +1,44 @@
 <script setup lang="ts">
-import { ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import useStoreLine from '../stores/konva/line'
 import ColorButton from './ToolBar/ColorButton.vue'
+import StrokeWidthRange from './ToolBar/StrokeWidthRange.vue'
 
-export type Color = 'red' | 'green' | 'blue'
+export type Color = 'red' | 'blue' | 'green'
 
-const { drawMode } = storeToRefs(useStoreLine())
-const { setStrokeWidth } = useStoreLine()
-const colors: Color[] = ['red', 'green', 'blue']
-
-const selectedStrokeWidth = ref()
+const { tool } = storeToRefs(useStoreLine())
+const { setTool, setGlobalCompositeOperation } = useStoreLine()
+const colors: Color[] = ['red', 'blue', 'green']
 </script>
 
 <template lang="pug">
 
 .flex.justify-center 
-  div(class="flex justify-center p-6 max-w-sm bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700 mt-3")
-    ul.flex 
+  div(class="flex justify-center items-center p-6 bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700 mt-3")
+    ul.flex
+      //- Pen
       li.flex.mr-2
-        button(v-show="!drawMode" class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded" @click="drawMode = !drawMode")
+        button(v-show="tool !== 'pen'" class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded" @click="() => {setTool('pen');setGlobalCompositeOperation()}")
           span(class="material-symbols-outlined") edit 
-        button(v-show="drawMode" class="bg-blue-500 hover:bg-blue-500 font-semibold text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded" @click="drawMode = !drawMode")
+        button(v-show="tool === 'pen'" class="bg-blue-500 hover:bg-blue-500 font-semibold text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded" @click="setTool('none')")
           span(class="material-symbols-outlined") edit 
+      //- Eraser
+      li.flex.mr-2
+        button(v-show="tool !== 'eraser'" class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded" @click="() => {setTool('eraser');setGlobalCompositeOperation()}")
+          span(class="material-symbols-outlined") delete
+        button(v-show="tool === 'eraser'" class="bg-blue-500 hover:bg-blue-500 font-semibold text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded" @click="setTool('none')")
+          span(class="material-symbols-outlined") delete
+      //- Undo
       li.flex.mr-2
         button(class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded")
           span(class="material-symbols-outlined") undo 
+      //- Redo
       li.flex.mr-2
         button(class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded")
           span(class="material-symbols-outlined") redo 
-  
-.flex.justify-center 
-    div(v-if="drawMode" class="flex p-6 max-w-sm bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700 absolute mt-3")
-      ColorButton(v-for="color of colors" :key="color" :color="color")
-      div(class="block") 
-        label(for="default-range" class="block mb-2 text-sm font-medium text-gray-900 dark:text-gray-300 text-center") Stroke Width 
-        input(
-          id="font-size"
-          ref="selectedStrokeWidth"
-          type="range"
-          value="1"
-          min="1"
-          max="10"
-          class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"
-          @change="setStrokeWidth(selectedStrokeWidth.value)")
+
+    ColorButton(v-for="color of colors" :key="color" :color="color")
+    
+    StrokeWidthRange
+
 </template>

--- a/src/components/ToolBar/ColorButton.vue
+++ b/src/components/ToolBar/ColorButton.vue
@@ -6,21 +6,11 @@ type Props = {
   color: Color
 }
 const props = defineProps<Props>()
-
+// eslint-disable-next-line vue/no-setup-props-destructure
 const { setColor } = useStoreLine()
 </script>
 
 <template lang="pug">
-div
-  button(class="bg-teal-200" @click="setColor(props.color)" )
-    span(class="material-symbols-outlined") circle
-    p {{props.color}}
+button(class="items-center" @click="setColor(color)")
+  div(class="rounded-full w-8 h-8 m-1 hover:scale-125" :style="{'background-color': props.color}")
 </template>
-
-<style scoped>
-.material-symbols-outlined {
-  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 48;
-  color: red;
-  font-size: 50px;
-}
-</style>

--- a/src/components/ToolBar/ColorButton.vue
+++ b/src/components/ToolBar/ColorButton.vue
@@ -5,8 +5,8 @@ import useStoreLine from '../../stores/konva/line'
 type Props = {
   color: Color
 }
+
 const props = defineProps<Props>()
-// eslint-disable-next-line vue/no-setup-props-destructure
 const { setColor } = useStoreLine()
 </script>
 

--- a/src/components/ToolBar/StrokeWidthRange.vue
+++ b/src/components/ToolBar/StrokeWidthRange.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import useStoreLine from '../../stores/konva/line'
+
+const { strokeWidth } = storeToRefs(useStoreLine())
+const { setStrokeWidth } = useStoreLine()
+const selectedStrokeWidth = ref()
+</script>
+
+<template lang="pug">
+div(class="block") 
+  label(for="step-range" class="block mb-2 text-sm font-medium text-gray-900 dark:text-gray-300 text-center") Stroke Width {{ strokeWidth }}
+  input(
+    id="steps-range"
+    ref="selectedStrokeWidth"
+    type="range"
+    value="1"
+    min="1"
+    max="10"
+    step="1"
+    class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"
+    @change="setStrokeWidth(selectedStrokeWidth.value)")
+</template>

--- a/src/stores/konva/line.ts
+++ b/src/stores/konva/line.ts
@@ -1,5 +1,7 @@
 import { defineStore } from 'pinia'
 
+type Tool = 'pen' | 'eraser' | 'none'
+
 interface Points {
   points: number[]
   color: string
@@ -9,14 +11,19 @@ interface Points {
 const useStoreLine = defineStore({
   id: 'line',
   state: () => ({
-    drawMode: false,
+    tool: 'none',
     isDrawing: false,
     drawColor: 'black', // default Color
     strokeWidth: 1, // default stroke width
+    globalCompositeOperation: 'source-over',
     lines: [] as Points[],
   }),
 
   actions: {
+    setTool(tool: Tool) {
+      this.tool = tool
+    },
+
     setColor(selectedColor: string) {
       this.drawColor = selectedColor
     },
@@ -25,18 +32,24 @@ const useStoreLine = defineStore({
       this.strokeWidth = parseInt(selectedStrokeWidth, 10)
     },
 
+    setGlobalCompositeOperation() {
+      this.globalCompositeOperation =
+        this.tool === 'eraser' ? 'destination-out' : 'source-over'
+    },
+
     setLines(line: Points) {
       this.lines = [...this.lines, line]
     },
 
     handleMouseDown(e: any) {
-      if (!this.drawMode) return
+      if (this.tool === 'none') return
       this.isDrawing = true
       const pos = e.target.getStage().getPointerPosition()
       const points = {
         points: [pos.x, pos.y],
         color: this.drawColor,
         strokeWidth: this.strokeWidth,
+        globalCompositeOperation: this.globalCompositeOperation,
       }
       this.setLines(points)
     },

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -79,7 +79,7 @@ div(class="p-5 bg-orange-100")
         v-line(
           v-for="line ,index in lines"
           :key="index"
-          :config="{stroke:line.color,points:line.points,strokeWidth:line.strokeWidth,tension:0.1,lineCap:'round',lineJoin:'round'}"
+          :config="{stroke:line.color,points:line.points,strokeWidth:line.strokeWidth,tension:0.1,lineCap:'round',lineJoin:'round', globalCompositeOperation: line.globalCompositeOperation}"
           )
         v-text(
           v-for="text, index in texts"


### PR DESCRIPTION
### 関連している Issue / 目的
#6 

### 達成条件
ドラッグでマウスで線を消せる

### 実装の概要 / この PR の対応範囲
消しゴムボタンを押すと消しゴムモードになり、マウスドラッグで書いた線を消せる。
ツールバーの周りをリファクタリング。

### 不安に思っていること
消しゴムのアイコンをfontawesomeから使おうと思ったが、なぜか反映されなかったので、暫定でゴミ箱のアイコンにしています。

### その他情報（スクリーンショット等）
参考ドキュメント： https://konvajs.org/docs/react/Free_Drawing.html
![Vite + Vue + TS - Google Chrome 2022_10_11 18_44_31](https://user-images.githubusercontent.com/96802323/195056781-ba829dbc-37d8-41cb-b7f5-cbd8e041702b.png)
