### PR TITLE
fix: #18 canvas responsive

### DIFF
--- a/src/stores/konva/line.ts
+++ b/src/stores/konva/line.ts
@@ -32,7 +32,7 @@ const useStoreLine = defineStore({
     handleMouseDown(e: any) {
       if (!this.drawMode) return
       this.isDrawing = true
-      const pos = e.target.getStage().getPointerPosition()
+      const pos = e.target.getStage().getRelativePointerPosition()
       const points = {
         points: [pos.x, pos.y],
         color: this.drawColor,
@@ -49,7 +49,7 @@ const useStoreLine = defineStore({
       // ステージを取得
       const stage = e.target.getStage()
       // ステージのx,yを取得
-      const point = stage.getPointerPosition()
+      const point = stage.getRelativePointerPosition()
       const lastLine = this.lines[this.lines.length - 1]
       // add point
       lastLine.points = lastLine.points.concat([point.x, point.y])

--- a/src/stores/konva/stage.ts
+++ b/src/stores/konva/stage.ts
@@ -18,12 +18,12 @@ const useStoreStage = defineStore({
   actions: {
     fitStageIntoParentContainer(container: HTMLDivElement) {
       // Fixed stage size
-      const SCENE_BASE_WIDTH = 800
-      const SCENE_BASE_HEIGHT = 600
+      const SCENE_BASE_WIDTH = 896
+      const SCENE_BASE_HEIGHT = 504
 
       // Max upscale
-      const SCENE_MAX_WIDTH = 1024
-      const SCENE_MAX_HEIGHT = 768
+      const SCENE_MAX_WIDTH = 1280
+      const SCENE_MAX_HEIGHT = 720
 
       const stageWidth =
         container.offsetWidth % 2 !== 0

--- a/src/stores/konva/stage.ts
+++ b/src/stores/konva/stage.ts
@@ -4,8 +4,10 @@ const useStoreStage = defineStore({
   id: 'stage',
   state: () => ({
     configKonva: {
-      width: window.innerWidth,
-      height: window.innerHeight / 1.5,
+      size: {
+        width: window.innerWidth,
+        height: window.innerWidth,
+      },
       scale: {
         x: 1,
         y: 1,
@@ -14,13 +16,35 @@ const useStoreStage = defineStore({
   }),
 
   actions: {
-    fitStageIntoParentContainer(container: any) {
-      const containerWidth = container.offsetWidth
-      const scale = containerWidth / this.configKonva.width
-      this.configKonva.width *= scale
-      // this.configKonva.height *= scale
-      this.configKonva.scale.x = scale
-      // this.configKonva.scale.y = scale
+    fitStageIntoParentContainer(container: HTMLDivElement) {
+      // Fixed stage size
+      const SCENE_BASE_WIDTH = 800
+      const SCENE_BASE_HEIGHT = 600
+
+      // Max upscale
+      const SCENE_MAX_WIDTH = 1024
+      const SCENE_MAX_HEIGHT = 768
+
+      const stageWidth =
+        container.offsetWidth % 2 !== 0
+          ? container.offsetWidth - 1
+          : container.offsetWidth
+
+      this.configKonva.size = {
+        width: stageWidth,
+        height: (stageWidth * 9) / 16, // aspect-ratio
+      }
+
+      const scaleX =
+        Math.min(this.configKonva.size.width, SCENE_MAX_WIDTH) /
+        SCENE_BASE_WIDTH
+
+      const scaleY =
+        Math.min(this.configKonva.size.height, SCENE_MAX_HEIGHT) /
+        SCENE_BASE_HEIGHT
+
+      const minRatio = Math.min(scaleX, scaleY)
+      this.configKonva.scale = { x: minRatio, y: minRatio }
     },
   },
 })

--- a/src/stores/konva/text.ts
+++ b/src/stores/konva/text.ts
@@ -68,7 +68,7 @@ const useStoreText = defineStore({
       // クリックしているのが、Stageでないならスキップ
       if (e.target !== stage) return
       // get x, y of Stage
-      const point = stage.getPointerPosition()
+      const point = stage.getRelativePointerPosition()
       // add text
       const id = nanoid()
       this.texts = [

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -63,9 +63,8 @@ div
     option(value="left") Left
     option(value="center") Center
     option(value="right") Right
-div(class="p-5 bg-orange-100")
-  div(ref="stageParentDiv" class="bg-white")
-
+div(class="flex justify-center items-center p-5 bg-slate-200")
+  div(ref="stageParentDiv" class="bg-white max-w-screen-lg w-full")
 
     v-stage(
       :config="configKonva"

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -63,8 +63,8 @@ div
     option(value="left") Left
     option(value="center") Center
     option(value="right") Right
-div(class="flex justify-center items-center p-5 bg-slate-200")
-  div(ref="stageParentDiv" class="bg-white max-w-screen-xl w-full")
+div(class="m-auto border-4 max-w-screen-xl")
+  div(ref="stageParentDiv" class="bg-white w-full")
 
     v-stage(
       :config="configKonva"

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -64,7 +64,7 @@ div
     option(value="center") Center
     option(value="right") Right
 div(class="flex justify-center items-center p-5 bg-slate-200")
-  div(ref="stageParentDiv" class="bg-white max-w-screen-lg w-full")
+  div(ref="stageParentDiv" class="bg-white max-w-screen-xl w-full")
 
     v-stage(
       :config="configKonva"


### PR DESCRIPTION
### 関連している Issue / 目的
#18 

### 達成条件
画面のサイズが変わってもキャンバス全体が表示される

### 実装の概要 / この PR の対応範囲
線を引く際、テキストを配置する際ののポインターの取得位置はRelativePositionをで取得するように変更

### 重点的にレビューしてほしいところ
canvasの最大幅を1280px、比率を16：9にしているがこの比率でよいか。

### 不安に思っていること
現状、Textの編集切替の際、TextAreaの倍率がそのままなのでTextAreaのスケールも要修正。

### その他情報（スクリーンショット等）
参考にした記事

- https://stackoverflow.com/questions/62905313/how-to-make-konva-react-responsive-scaling-canvas-according-to-device-size-r
- 

![ダウンロード](https://user-images.githubusercontent.com/96802323/196019396-751fa2c6-48d2-480c-b100-8a34c6e2eb92.gif)
