### PR TITLE
feat: export canvas to image

### DIFF
--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -1,9 +1,16 @@
 <script setup lang="ts">
 import { reactive } from 'vue'
 import { storeToRefs } from 'pinia'
+import Konva from 'konva'
 import useStoreMode, { type Mode } from '@/stores/mode'
 import useStoreLine from '@/stores/konva/line'
 import SubToolMenu from '@/components/SubToolMenu.vue'
+
+interface Props {
+  stage: Konva.Stage
+}
+
+const props = defineProps<Props>()
 
 const { mode } = storeToRefs(useStoreMode())
 const { setMode } = useStoreMode()
@@ -83,6 +90,23 @@ const toolArray: {
     },
   },
 ])
+
+const downloadURI = (uri: string, name: string) => {
+  const link = document.createElement('a')
+  link.download = name
+  link.href = uri
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+}
+
+const saveImage = () => {
+  const dataURL = props.stage.getStage().toDataURL({
+    quality: 1,
+    pixelRatio: 2,
+  })
+  downloadURI(dataURL, 'stage.png')
+}
 </script>
 
 <template lang="pug">
@@ -104,4 +128,8 @@ div(class="flex flex-col items-center absolute bottom-2 left-1/2 -translate-x-1/
       li.flex.mx-2
         button(type="button" class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded")
           span(class="material-symbols-outlined") redo 
+      //- Download
+      li.flex.mx-2
+        button(type="button" class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded" @click="saveImage")
+          span(class="material-symbols-outlined") file_download
 </template>

--- a/src/stores/konva/text.ts
+++ b/src/stores/konva/text.ts
@@ -75,39 +75,41 @@ const useStoreText = defineStore({
   actions: {
     createNewTextNode(e: Konva.KonvaEventObject<MouseEvent>, mode: Mode) {
       if (mode !== 'text') return
+      // クリックしているのが、Textならスキップ
+      if (e.target.className === 'Text') return
       // get Stage
       const stage = e.target.getStage()
-      // クリックしているのが、Stageでないならスキップ
-      if (e.target !== stage) return
-      // get x, y of Stage
-      const point = stage.getRelativePointerPosition()
-      // add text
-      const id = nanoid()
-      this.texts = [
-        ...this.texts,
-        {
-          id,
-          text: 'Double click to edit text...',
-          rotation: 0,
-          x: point.x,
-          y: point.y,
-          scaleX: 1,
-          scaleY: 1,
-          fontSize: this.fontSize,
-          fontStyle: this.fontStyle as FontStyle,
-          textDecoration: this.textDecoration as TextDecoration,
-          fontFamily: 'Arial',
-          align: this.align as TextAlign,
-          verticalAlign: this.verticalAlign as TextVerticalAlign,
-          draggable: true,
-          width: 200,
-          height: 100,
-          fill: this.fill,
-          wrap: 'word',
-          ellipsis: false,
-          name: `${id}`,
-        },
-      ]
+      if (stage !== null) {
+        // get x, y of Stage
+        const point = stage.getRelativePointerPosition()
+        // add text
+        const id = nanoid()
+        this.texts = [
+          ...this.texts,
+          {
+            id,
+            text: 'Double click to edit text...',
+            rotation: 0,
+            x: point.x,
+            y: point.y,
+            scaleX: 1,
+            scaleY: 1,
+            fontSize: this.fontSize,
+            fontStyle: this.fontStyle as FontStyle,
+            textDecoration: this.textDecoration as TextDecoration,
+            fontFamily: 'Arial',
+            align: this.align as TextAlign,
+            verticalAlign: this.verticalAlign as TextVerticalAlign,
+            draggable: true,
+            width: 200,
+            height: 100,
+            fill: this.fill,
+            wrap: 'word',
+            ellipsis: false,
+            name: `${id}`,
+          },
+        ]
+      }
     },
 
     setTextOptionValue(

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -72,6 +72,7 @@ div(class="m-auto border-4 max-w-screen-xl relative my-8")
       //- @touchstart="(e:Konva.KonvaEventObject<TouchEvent>) => handleStageMouseDown(e, transformer)"
 
       v-layer
+        v-rect(:config="{name: 'background-rect', x: 0, y: 0, width: configKonva.size.width / configKonva.scale.x, height: configKonva.size.height / configKonva.scale.y, fill: '#FFFFFF'}")
         v-line(
           v-for="line ,index in lines"
           :key="index"
@@ -87,5 +88,5 @@ div(class="m-auto border-4 max-w-screen-xl relative my-8")
           )
         v-transformer(ref="transformer" :config="configTransformer")
 
-ToolBar 
+ToolBar(:stage="stage")
 </template>


### PR DESCRIPTION
### 関連している Issue / 目的
#31 

### 実装の概要 / この PR の対応範囲
ダウンロードボタンをクリックするとstage.pngというファイル名で画像をダウンロードできる

### 不安に思っていること
Composition APIでのpropsの渡し方があっているか不安。（ToolBar.vue）

### 備考
将来的には、ダウンロードのデータ形式を変更できたり、保存名が作品の名前になるように設定したい