### PR TITLE
Feat/fetchedcanvas to canvas history

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ## 技術スタック
 
 ### フロントエンド
+
 - Vue3
 - TypeScript
 - tailwindCSS
@@ -15,28 +16,34 @@
 - konva
 - Vue konva
 
-### 各種Linterなど
+### 各種 Linter など
+
 - ESLint
 - Prettier
 - Commit Lint
 - husky
 
 ### バックエンド、データベース
+
 - FireBase
 
 ### テストツール
+
 - Jest
 
 ### ビルドツール
+
 - Vite
 
 ### CI/CD
+
 - Github Actions
 
 ### ホスティングサービス
+
 - Github Pages
 
-
 ## URL
-下記からお試しください↓
+
+下記からお試しください ↓
 https://oekakiapp.github.io/Front/

--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -132,6 +132,10 @@ const downloadURI = (uri: string, name: string) => {
 }
 
 const saveImage = () => {
+  // 選択解除
+  selectedShapeId.value = ''
+  configShapeTransformer.value.nodes = []
+  // なぜか出力した画像上では選択が解除されない…（props.stageが非リアクティブ?）
   const dataURL = props.stage.getStage().toDataURL({
     quality: 1,
     pixelRatio: 2,
@@ -166,7 +170,6 @@ input(id="my-modal" type="checkbox" className="modal-toggle")
 div(className="modal")
   div(className="modal-box")
     h3(className="font-bold text-2xl") キャンバスをリセットしてよろしいですか？
-    p(className="py-4 text-red-600") ※ この操作は取り消せません。
     div(class="flex justify-end")
       div(className="modal-action mr-3")
         label(htmlFor="my-modal" className="btn w-36") Cancel

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -22,13 +22,14 @@ import useStorePointer from '@/stores/konva/pointer'
 import useStoreTransformer from '@/stores/konva/transformer'
 import Konva from 'konva'
 import WebFont from 'webfontloader'
+import _ from 'lodash'
 
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 type KonvaEventObject<T> = Konva.KonvaEventObject<T>
 const StorageReference = storageRef(storage, '')
 
 const { mode } = storeToRefs(useStoreMode())
-const { configKonva } = storeToRefs(useStoreStage())
+const { configKonva, historyStep, canvasHistory } = storeToRefs(useStoreStage())
 const { lines } = storeToRefs(useStoreLine())
 const { texts, isEditing, isFontLoaded } = storeToRefs(useStoreText())
 const { canvases } = storeToRefs(useAuthStore())
@@ -125,6 +126,37 @@ onMounted(() => {
     handleKeyDownSelectedNodeDelete(e)
   })
 
+  // 初期化
+  mode.value = 'none'
+  lines.value = []
+  texts.value = []
+  konvaImages.value = []
+  // 履歴初期化
+  canvasHistory.value = [{ lines: [], texts: [], images: [] }]
+  historyStep.value = 0
+
+  const canvasVal = canvasId.value
+  // 途中からの場合
+  if (
+    typeof canvasVal === 'string' &&
+    canvases.value[canvasVal] !== undefined
+  ) {
+    const canvas = canvases.value[canvasVal]
+    lines.value = _.cloneDeep(canvas.lines)
+    texts.value = _.cloneDeep(canvas.texts)
+    konvaImages.value = _.cloneDeep(canvas.konvaImages ?? [])
+    inputText.text = canvas.name
+    // 履歴をセット
+    canvasHistory.value = [
+      {
+        lines: _.cloneDeep(canvas.lines),
+        texts: _.cloneDeep(canvas.texts),
+        images: _.cloneDeep(canvas.konvaImages ?? []),
+      },
+    ]
+    historyStep.value = 0
+  }
+
   // Font読み込み
   if (!isFontLoaded.value) {
     WebFont.load({
@@ -141,23 +173,6 @@ onMounted(() => {
       },
     })
   }
-  // 初期化
-  lines.value = []
-  texts.value = []
-  konvaImages.value = []
-
-  const canvasVal = canvasId.value
-  // 途中からの場合
-  if (
-    typeof canvasVal === 'string' &&
-    canvases.value[canvasVal] !== undefined
-  ) {
-    const canvas = canvases.value[canvasVal]
-    lines.value = canvas.lines
-    texts.value = canvas.texts
-    konvaImages.value = canvas.konvaImages ?? []
-    inputText.text = canvas.name
-  }
 })
 
 onUnmounted(() => {
@@ -171,6 +186,9 @@ onUnmounted(() => {
 })
 
 async function saveCanvas(): Promise<void> {
+  // 選択を解除
+  selectedShapeId.value = ''
+  configShapeTransformer.value.nodes = []
   // 途中からの場合
   const canvasVal = canvasId.value
   if (
@@ -288,7 +306,6 @@ div(class="m-auto border-4 border-orange-100 max-w-screen-xl my-4")
       )
       v-layer
         v-rect(:config="{name: 'background-rect', x: 0, y: 0, width: configKonva.size.width / configKonva.scale.x, height: configKonva.size.height / configKonva.scale.y, fill: '#FFFFFF'}")
-      v-layer
         v-image(
           v-for="image in konvaImages"
           :key="image.id"
@@ -302,11 +319,6 @@ div(class="m-auto border-4 border-orange-100 max-w-screen-xl my-4")
           @transform="(e: KonvaEventObject<MouseEvent>) => handleTransform(e)"
           @transformend="handleTransformEnd"
         )
-        v-line(
-          v-for="line in lines"
-          :key="line.id"
-          :config="{id: line.id, name: line.name, stroke:line.color, points:line.points, strokeWidth:line.strokeWidth, dash: line.dash, dashEnabled: line.dashEnabled, tension:0.1, lineCap:'round', lineJoin:'round', globalCompositeOperation: line.globalCompositeOperation}"
-          )
         v-text(
           v-for="text in texts"
           :key="text.id"
@@ -319,6 +331,12 @@ div(class="m-auto border-4 border-orange-100 max-w-screen-xl my-4")
           @mouseleave="(e: KonvaEventObject<MouseEvent>) => {handlePointerMouseLeave(e);}"
           @transform="(e: KonvaEventObject<MouseEvent>) => handleTransform(e)"
           @dblclick="(e: KonvaEventObject<MouseEvent>) => toggleEdit(e, transformer, stageParentDiv)"
+          )
+      v-layer
+        v-line(
+          v-for="line in lines"
+          :key="line.id"
+          :config="{id: line.id, name: line.name, stroke:line.color, points:line.points, strokeWidth:line.strokeWidth, dash: line.dash, dashEnabled: line.dashEnabled, tension:0.1, lineCap:'round', lineJoin:'round', globalCompositeOperation: line.globalCompositeOperation}"
           )
         //- pen eraser時のcursor
         UserCursor

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -183,6 +183,9 @@ onUnmounted(() => {
     changeModeByShortCut(e)
     handleKeyDownSelectedNodeDelete(e)
   })
+  // 選択を解除
+  selectedShapeId.value = ''
+  configShapeTransformer.value.nodes = []
 })
 
 async function saveCanvas(): Promise<void> {


### PR DESCRIPTION
### 達成条件
fetchしたキャンバスの履歴を初期状態としてセットする
createPageから離れたとき要素の選択状態を解除する。

### 実装の概要 / この PR の対応範囲

1. fetchしたキャンバスの状態を履歴に保存
2. createPageがunmountされた時に選択状態を解除する
3. save時に選択状態を解除する

### 重点的にレビューしてほしいところ

### 不安に思っていること
なぜかダウンロード時には選択状態が解除できず、Transformerが画像化されてしまう。
親コンポーネントから受け取ったpropsがリアクティブになっていないためか？

### その他情報（スクリーンショット等）
