### PR TITLE
fix: 新規登録で、icon編集できない

### DIFF
--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -44,13 +44,12 @@ const useAuthStore = defineStore('auth', {
             displayName: name,
           })
             .then(async () => {
+              // database usersを作成
               await setDoc(doc(db, 'users', user.uid), {
-                profile: user.displayName,
+                profile: 'よろしくお願いします。',
                 uid: user.uid,
               })
-            })
-            .then(async () => {
-              this.name = name
+              await this.setUser(user)
               await forceToWorkPage()
             })
             .catch((error) => {
@@ -64,10 +63,7 @@ const useAuthStore = defineStore('auth', {
     loginEmail(email: string, password: string) {
       const auth = getAuth()
       signInWithEmailAndPassword(auth, email, password)
-        .then(async (userCredential) => {
-          const { user } = userCredential
-          await this.setUser(user)
-          await this.getCanvases()
+        .then(async () => {
           await forceToWorkPage()
         })
         .catch((error) => {
@@ -93,26 +89,17 @@ const useAuthStore = defineStore('auth', {
       this.isLoggedIn = true
       localStorage.setItem('usersId', user.uid)
       // get profile
-      const userQuery = query(
-        collection(db, 'users'),
-        where('uid', '==', user.uid),
-      )
-      await getDocs(userQuery)
-        .then((querySnapshot) => {
-          querySnapshot.forEach((document) => {
-            this.profile = document.data().profile
-          })
-        })
-        .catch((error) => {
-          console.log(error)
-        })
+      const userDocRef = doc(db, 'users', this.uid)
+      const userDocSnap = await getDoc(userDocRef)
+      if (userDocSnap.exists()) {
+        this.profile = userDocSnap.data().profile
+      }
     },
 
     async getCanvases() {
-      const usersId: string = localStorage.getItem('usersId') ?? ''
       const canvasQuery = query(
         collection(db, 'canvas'),
-        where('uid', '==', usersId),
+        where('uid', '==', this.uid),
       )
 
       await getDocs(canvasQuery)

--- a/src/views/ProfileSettingsPage.vue
+++ b/src/views/ProfileSettingsPage.vue
@@ -14,6 +14,7 @@ import {
 const authUser = getAuth().currentUser!
 const authStore = useAuthStore()
 const icon = ref(authStore.icon)
+let uploadFile = new File([], '')
 
 const iconRef = ref<HTMLInputElement | null>(null)
 
@@ -46,16 +47,16 @@ const saveProfile = () => {
 
 const onFileUploadToFirebase = () => {
   if (iconRef.value && iconRef.value.files) {
-    const file: File = iconRef.value.files[0]
-    icon.value = URL.createObjectURL(file)
+    // prefer-destructuring
+    uploadFile = iconRef.value.files[0] // eslint-disable-line
+    icon.value = URL.createObjectURL(uploadFile)
   }
 }
 
 const updateFireBase = async () => {
   // profile
   if (authStore.profile !== textArea.text) {
-    const usersId: string = localStorage.getItem('usersId') ?? ''
-    const washingtonRef = doc(db, 'users', usersId)
+    const washingtonRef = doc(db, 'users', authStore.uid)
     await updateDoc(washingtonRef, {
       profile: textArea.text,
     })
@@ -75,10 +76,9 @@ const updateFireBase = async () => {
       })
   }
   // icon
-  if (authStore.icon !== icon.value && iconRef.value && iconRef.value.files) {
-    const file: File = iconRef.value.files[0]
-    const fileRef = storageRef(storage, `user-image/${file.name}`)
-    const uploadTask = uploadBytesResumable(fileRef, file)
+  if (authStore.icon !== icon.value) {
+    const fileRef = storageRef(storage, `user-image/${uploadFile.name}`)
+    const uploadTask = uploadBytesResumable(fileRef, uploadFile)
 
     uploadTask.on(
       'state_changed',


### PR DESCRIPTION
### 関連している Issue / 目的

#67 

### 達成条件

- 新規登録した後、iconを変更できるようにする

### 実装の概要 / この PR の対応範囲

- 新規登録後プロフィール変更で iconのプレビューは変わる。
しかし、`iconRef.value`が`null`になり、upload されない。原因不明
対応として、変数`uploadFile`を設置した。動作問題なし。

- usersコレクション(profile)のドキュメント名が`user uid`に変更されたので、取得方法変更。

### 不安に思っていること

`uploadFile`変数を設けたのは良いが、eslintで怒られた。
配列が大きくて、対処方法がわからない
