### PR TITLE
Feat/auth error

### DIFF
--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -33,6 +33,8 @@ const useAuthStore = defineStore('auth', {
     isLoggedIn: false,
     canvases: {} as DocumentData, // eslint-disable-line
     //  @typescript-eslint/consistent-type-assertions
+    isAuthError: false,
+    authErrorMessage: ''
   }),
   actions: {
     signupEmail(email: string, password: string, name: string) {
@@ -67,7 +69,8 @@ const useAuthStore = defineStore('auth', {
           await forceToWorkPage()
         })
         .catch((error) => {
-          console.log(error.message)
+          this.isAuthError = true
+          this.authErrorMessage = errorHash[error.code] !== undefined ? errorHash[error.code] : '認証に失敗しました。しばらく時間をおいて再度お試しください'
         })
     },
     logout() {
@@ -133,6 +136,18 @@ async function forceToHomePage() {
   await router.replace({
     name: 'Home',
   })
+}
+
+const errorHash = {
+  // 新規登録
+  'auth/email-already-in-use': 'このメールアドレスは使用されています',
+  'auth/invalid-email': 'メールアドレスの形式が正しくありません',
+  'auth/weak-password': 'パスワードは6文字以上にしてください',
+  // ログイン
+  'auth/user-not-found': 'メールアドレスまたはパスワードが違います',
+  'auth/wrong-password': 'パスワードが違います',
+  'auth/user-disabled': 'サービスの利用が停止されています',
+  'auth/too-many-requests': 'パスワードを忘れましたか？\nパスワードリセットは現在利用できません'
 }
 
 export default useAuthStore

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -59,12 +59,7 @@ const useAuthStore = defineStore('auth', {
             })
         })
         .catch((error) => {
-          const code: string = error.code
-          this.isAuthError = true
-          this.authErrorMessage =
-            errorMap.get(code) !== undefined
-              ? errorMap.get(code)
-              : '認証に失敗しました。しばらく時間をおいて再度お試しください'
+          this.authError(error)
         })
     },
     loginEmail(email: string, password: string) {
@@ -74,12 +69,7 @@ const useAuthStore = defineStore('auth', {
           await forceToWorkPage()
         })
         .catch((error) => {
-          const code: string = error.code
-          this.isAuthError = true
-          this.authErrorMessage =
-            errorMap.get(code) !== undefined
-              ? errorMap.get(code)
-              : '認証に失敗しました。しばらく時間をおいて再度お試しください'
+          this.authError(error)
         })
     },
     logout() {
@@ -92,6 +82,15 @@ const useAuthStore = defineStore('auth', {
         .catch((error) => {
           console.log(error.message)
         })
+    },
+
+    authError(error: any) {
+      const { code } = error
+      this.isAuthError = true
+      this.authErrorMessage =
+        errorMap.get(code) !== undefined
+          ? errorMap.get(code)
+          : '認証に失敗しました。しばらく時間をおいて再度お試しください'
     },
 
     async setUser(user: User) {

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -34,7 +34,7 @@ const useAuthStore = defineStore('auth', {
     canvases: {} as DocumentData, // eslint-disable-line
     //  @typescript-eslint/consistent-type-assertions
     isAuthError: false,
-    authErrorMessage: '',
+    authErrorMessage: '' as string | undefined,
   }),
   actions: {
     signupEmail(email: string, password: string, name: string) {
@@ -59,7 +59,12 @@ const useAuthStore = defineStore('auth', {
             })
         })
         .catch((error) => {
-          console.log(error.message)
+          const code: string = error.code
+          this.isAuthError = true
+          this.authErrorMessage =
+            errorMap.get(code) !== undefined
+              ? errorMap.get(code)
+              : '認証に失敗しました。しばらく時間をおいて再度お試しください'
         })
     },
     loginEmail(email: string, password: string) {
@@ -69,10 +74,11 @@ const useAuthStore = defineStore('auth', {
           await forceToWorkPage()
         })
         .catch((error) => {
+          const code: string = error.code
           this.isAuthError = true
           this.authErrorMessage =
-            errorHash[error.code] !== undefined
-              ? errorHash[error.code]
+            errorMap.get(code) !== undefined
+              ? errorMap.get(code)
               : '認証に失敗しました。しばらく時間をおいて再度お試しください'
         })
     },
@@ -141,17 +147,19 @@ async function forceToHomePage() {
   })
 }
 
-const errorHash = {
+const errorMap = new Map([
   // 新規登録
-  'auth/email-already-in-use': 'このメールアドレスは既に使用されています',
-  'auth/invalid-email': 'メールアドレスの形式が正しくありません',
-  'auth/weak-password': 'パスワードは6文字以上 入力してください',
+  ['auth/email-already-in-use', 'このメールアドレスは既に使用されています'],
+  ['auth/invalid-email', 'メールアドレスの形式が正しくありません'],
+  ['auth/weak-password', 'パスワードは6文字以上 入力してください'],
   // ログイン
-  'auth/user-not-found': 'メールアドレスまたはパスワードが正しくありません',
-  'auth/wrong-password': '正しいパスワードを入力してください',
-  'auth/user-disabled': 'サービスの利用が停止されています',
-  'auth/too-many-requests':
+  ['auth/user-not-found', 'メールアドレスまたはパスワードが正しくありません'],
+  ['auth/wrong-password', '正しいパスワードを入力してください'],
+  ['auth/user-disabled', 'サービスの利用が停止されています'],
+  [
+    'auth/too-many-requests',
     'パスワードを忘れましたか？\nパスワードリセットは現在利用できません',
-}
+  ],
+])
 
 export default useAuthStore

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -34,7 +34,7 @@ const useAuthStore = defineStore('auth', {
     canvases: {} as DocumentData, // eslint-disable-line
     //  @typescript-eslint/consistent-type-assertions
     isAuthError: false,
-    authErrorMessage: ''
+    authErrorMessage: '',
   }),
   actions: {
     signupEmail(email: string, password: string, name: string) {
@@ -70,7 +70,10 @@ const useAuthStore = defineStore('auth', {
         })
         .catch((error) => {
           this.isAuthError = true
-          this.authErrorMessage = errorHash[error.code] !== undefined ? errorHash[error.code] : '認証に失敗しました。しばらく時間をおいて再度お試しください'
+          this.authErrorMessage =
+            errorHash[error.code] !== undefined
+              ? errorHash[error.code]
+              : '認証に失敗しました。しばらく時間をおいて再度お試しください'
         })
     },
     logout() {
@@ -140,14 +143,15 @@ async function forceToHomePage() {
 
 const errorHash = {
   // 新規登録
-  'auth/email-already-in-use': 'このメールアドレスは使用されています',
+  'auth/email-already-in-use': 'このメールアドレスは既に使用されています',
   'auth/invalid-email': 'メールアドレスの形式が正しくありません',
-  'auth/weak-password': 'パスワードは6文字以上にしてください',
+  'auth/weak-password': 'パスワードは6文字以上 入力してください',
   // ログイン
-  'auth/user-not-found': 'メールアドレスまたはパスワードが違います',
-  'auth/wrong-password': 'パスワードが違います',
+  'auth/user-not-found': 'メールアドレスまたはパスワードが正しくありません',
+  'auth/wrong-password': '正しいパスワードを入力してください',
   'auth/user-disabled': 'サービスの利用が停止されています',
-  'auth/too-many-requests': 'パスワードを忘れましたか？\nパスワードリセットは現在利用できません'
+  'auth/too-many-requests':
+    'パスワードを忘れましたか？\nパスワードリセットは現在利用できません',
 }
 
 export default useAuthStore

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -10,6 +10,7 @@ import {
   signInWithEmailAndPassword,
   updateProfile,
   User,
+  AuthError,
 } from 'firebase/auth'
 import {
   query,
@@ -84,7 +85,7 @@ const useAuthStore = defineStore('auth', {
         })
     },
 
-    authError(error: any) {
+    authError(error: AuthError) {
       const { code } = error
       this.isAuthError = true
       this.authErrorMessage =

--- a/src/views/LoginPage.vue
+++ b/src/views/LoginPage.vue
@@ -1,41 +1,41 @@
 <script setup lang="ts">
-import { reactive } from "vue";
-import router from "@/router/index";
-import useAuthStore from "@/stores/auth";
+import { reactive } from 'vue'
+import router from '@/router/index'
+import useAuthStore from '@/stores/auth'
 // import { InputTextType } from '@/types/index'
 interface InputTextType {
-  icon: string;
-  inputType: string;
-  placeholder: string;
-  text: string;
+  icon: string
+  inputType: string
+  placeholder: string
+  text: string
 }
-const authStore = useAuthStore();
+const authStore = useAuthStore()
 
 const inputTexts: InputTextType[] = reactive([
   {
-    icon: "mail",
-    inputType: "email",
-    placeholder: "Type Your Email",
-    text: "",
+    icon: 'mail',
+    inputType: 'email',
+    placeholder: 'Type Your Email',
+    text: '',
   },
   {
-    icon: "key",
-    inputType: "password",
-    placeholder: "Type Your Password",
-    text: "",
+    icon: 'key',
+    inputType: 'password',
+    placeholder: 'Type Your Password',
+    text: '',
   },
-]);
+])
 
 const submitLogin = () => {
-  const email = inputTexts[0].text;
-  const password = inputTexts[1].text;
-  authStore.loginEmail(email, password);
-};
+  const email = inputTexts[0].text
+  const password = inputTexts[1].text
+  authStore.loginEmail(email, password)
+}
 
 router.beforeEach(() => {
-  useAuthStore().isAuthError = false;
-  useAuthStore().authErrorMessage = "";
-});
+  useAuthStore().isAuthError = false
+  useAuthStore().authErrorMessage = ''
+})
 </script>
 
 <template lang="pug">

--- a/src/views/LoginPage.vue
+++ b/src/views/LoginPage.vue
@@ -15,13 +15,13 @@ const inputTexts: InputTextType[] = reactive([
   {
     icon: 'mail',
     inputType: 'email',
-    placeholder: 'Type Your Email',
+    placeholder: 'メールアドレス',
     text: '',
   },
   {
     icon: 'key',
     inputType: 'password',
-    placeholder: 'Type Your Password',
+    placeholder: 'パスワード',
     text: '',
   },
 ])

--- a/src/views/LoginPage.vue
+++ b/src/views/LoginPage.vue
@@ -1,65 +1,51 @@
 <script setup lang="ts">
-import { reactive } from 'vue'
-import useAuthStore from '@/stores/auth'
+import { reactive } from "vue";
+import router from "@/router/index";
+import useAuthStore from "@/stores/auth";
 // import { InputTextType } from '@/types/index'
 interface InputTextType {
-  icon: string
-  inputType: string
-  placeholder: string
-  text: string
-  isAlert: boolean
-  alertText: string
+  icon: string;
+  inputType: string;
+  placeholder: string;
+  text: string;
 }
-const authStore = useAuthStore()
+const authStore = useAuthStore();
 
 const inputTexts: InputTextType[] = reactive([
   {
-    icon: 'mail',
-    inputType: 'email',
-    placeholder: 'Type Your Email',
-    text: '',
-    isAlert: false,
-    alertText: 'メールアドレスを入力してください',
+    icon: "mail",
+    inputType: "email",
+    placeholder: "Type Your Email",
+    text: "",
   },
   {
-    icon: 'key',
-    inputType: 'password',
-    placeholder: 'Type Your Password',
-    text: '',
-    isAlert: false,
-    alertText: 'パスワードを入力してください',
+    icon: "key",
+    inputType: "password",
+    placeholder: "Type Your Password",
+    text: "",
   },
-])
+]);
 
 const submitLogin = () => {
-  const email = inputTexts[0].text
-  const password = inputTexts[1].text
-  validate()
-  authStore.loginEmail(email, password)
-}
+  const email = inputTexts[0].text;
+  const password = inputTexts[1].text;
+  authStore.loginEmail(email, password);
+};
 
-const validate = () => {
-  inputTexts.map((_inputText) => {
-    const inputText: InputTextType = _inputText
-    if (inputText.text === '') {
-      inputText.isAlert = true
-    } else {
-      inputText.isAlert = false
-    }
-    return inputText
-  })
-}
+router.beforeEach(() => {
+  useAuthStore().isAuthError = false;
+  useAuthStore().authErrorMessage = "";
+});
 </script>
 
 <template lang="pug">
 div(class="mt-16 my-8 lg:w-1/2 w-4/5 m-auto")
   h2(class="sm:text-4xl text-2xl font-bold text-midnightBlue text-center md:mb-20 mb-12") ログイン
   form(class="mx-auto" @submit.prevent="submitLogin")
+    //- alert
+    div(v-show='authStore.isAuthError' class="w-full p-2 my-4 text-sm text-red-700 bg-red-100 rounded-lg" role="alert")
+      span(class="font-medium whitespace-pre-wrap") {{authStore.authErrorMessage}}
     div(v-for="(inputText, index) in inputTexts" :key="index" class="mb-8")
-      //- alert
-      div(v-show="inputText.isAlert" class="w-full p-2 my-4 text-sm text-red-700 bg-red-100 rounded-lg" role="alert")
-        span(class="font-medium") {{inputText.alertText}}
-
       div(class="flex items-center justify-center w-full")
         span(class="material-symbols-outlined mr-2") {{inputText.icon}}
         div(class="w-full flex-fill mb-0")

--- a/src/views/SignUpPage.vue
+++ b/src/views/SignUpPage.vue
@@ -17,7 +17,7 @@ const inputTexts: InputTextType[] = reactive([
   {
     icon: 'person',
     inputType: 'text',
-    placeholder: 'お名前',
+    placeholder: '名前',
     text: '',
     isAlert: false,
     alertText: '名前を入力してください',

--- a/src/views/SignUpPage.vue
+++ b/src/views/SignUpPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { reactive } from 'vue'
+import router from '@/router/index'
 import useAuthStore from '@/stores/auth'
 // import { InputTextType } from '@/types/index'
 interface InputTextType {
@@ -16,7 +17,7 @@ const inputTexts: InputTextType[] = reactive([
   {
     icon: 'person',
     inputType: 'text',
-    placeholder: 'Type Your Name',
+    placeholder: 'お名前',
     text: '',
     isAlert: false,
     alertText: '名前を入力してください',
@@ -24,7 +25,7 @@ const inputTexts: InputTextType[] = reactive([
   {
     icon: 'mail',
     inputType: 'email',
-    placeholder: 'Type Your Email',
+    placeholder: 'メールアドレス',
     text: '',
     isAlert: false,
     alertText: 'メールアドレスを入力してください',
@@ -32,59 +33,61 @@ const inputTexts: InputTextType[] = reactive([
   {
     icon: 'lock',
     inputType: 'password',
-    placeholder: 'Type Your Password',
+    placeholder: 'パスワード6文字以上',
     text: '',
     isAlert: false,
-    alertText: 'パスワードを入力してください',
+    alertText: 'パスワードは6文字以上 入力してください',
   },
   {
     icon: 'key',
     inputType: 'password',
-    placeholder: 'Repeat Your Password',
+    placeholder: 'パスワード再入力',
     text: '',
     isAlert: false,
     alertText: 'パスワードが一致しません',
   },
 ])
 
-// TODO: 関数書き換え(map中 他textとの条件複雑になる) && 条件の見直し
 const submitSignup = () => {
   const name = inputTexts[0].text
   const email = inputTexts[1].text
   const password = inputTexts[2].text
   validate()
-  if (
-    !inputTexts[0].isAlert &&
-    !inputTexts[1].isAlert &&
-    !inputTexts[2].isAlert &&
-    !inputTexts[3].isAlert
-  ) {
+  if (!inputTexts[2].isAlert && !inputTexts[3].isAlert) {
     authStore.signupEmail(email, password, name)
+  } else {
+    authStore.isAuthError = true
+    // パスワードのエラー優先
+    if (inputTexts[2].isAlert) {
+      authStore.authErrorMessage = inputTexts[2].alertText
+    } else if (inputTexts[3].isAlert) {
+      authStore.authErrorMessage = inputTexts[3].alertText
+    }
   }
 }
 
 const validate = () => {
-  const name = inputTexts[0].text
-  const email = inputTexts[1].text
   const password = inputTexts[2].text
   const rePassword = inputTexts[3].text
 
-  inputTexts[0].isAlert = name === ''
-  inputTexts[1].isAlert = email === ''
-  inputTexts[2].isAlert = password === ''
+  inputTexts[2].isAlert = password.length < 6
   inputTexts[3].isAlert = rePassword !== password
 }
+
+router.beforeEach(() => {
+  useAuthStore().isAuthError = false
+  useAuthStore().authErrorMessage = ''
+})
 </script>
 
 <template lang="pug">
 div(class="mt-16 my-8 lg:w-1/2 w-4/5 m-auto")
   h2(class="sm:text-4xl text-2xl font-bold text-midnightBlue text-center md:mb-20 mb-12") 新規登録
   form(class="mx-auto" @submit.prevent="submitSignup")
+    //- alert
+    div(v-show='authStore.isAuthError' class="w-full p-2 my-4 text-sm text-red-700 bg-red-100 rounded-lg" role="alert")
+      span(class="font-medium whitespace-pre-wrap") {{authStore.authErrorMessage}}
     div(v-for="(inputText, index) in inputTexts" :key="index" class="mb-8")
-      //- alert
-      div(v-show="inputText.isAlert" class="w-full p-2 my-4 text-sm text-red-700 bg-red-100 rounded-lg" role="alert")
-        span(class="font-medium") {{inputText.alertText}}
-
       div(class="flex items-center justify-center w-full")
         span(class="material-symbols-outlined mr-2") {{inputText.icon}}
         div(class="w-full flex-fill mb-0")


### PR DESCRIPTION
### 関連している Issue / 目的

#64 

### 達成条件

- 認証エラー時にユーザーに知らせる。

### 実装の概要 / この PR の対応範囲

- 新規登録、ログイン時のエラーを alert で表示
- placeholderを日本語に修正

### 重点的にレビューしてほしいところ

- `store/auth` 87行目　型を`any`にしています
型作れるようですが、少し時間掛かりそうだったのでパス

- エラーメッセージの文言はこれで良いか

### その他情報（スクリーンショット等）

![スクリーンショット 2022-11-12 20 55 08](https://user-images.githubusercontent.com/68400191/201472939-47efacc5-e6fa-489c-89ac-10836a55a9a3.png)

