### PR TITLE
リロードの挙動を修正

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -85,7 +85,7 @@ async function autoLogin(to: RouteLocationNormalized) {
       if (user != null) {
         await authStore.setUser(user)
         await authStore.getCanvases()
-        if (to.name === 'Home') {
+        if (to.name === 'Home' || to.meta.requiresAuth === false) {
           await forceToWorksPage()
         }
         console.log('ログイン成功')

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -85,7 +85,9 @@ async function autoLogin(to: RouteLocationNormalized) {
       if (user != null) {
         await authStore.setUser(user)
         await authStore.getCanvases()
-        await forceToWorksPage()
+        if (to.name === 'Home') {
+          await forceToWorksPage()
+        }
         console.log('ログイン成功')
       } else {
         console.log('ログイン失敗')


### PR DESCRIPTION
### 関連している Issue

#80 自動ログイン機能の修正

### 達成条件

リロードしても、作業中のページにとどまるようにする

### 実装の概要 / この PR の対応範囲

ホーム、ログイン、新規登録ページで自動ログインした時はworksページに自動遷移するように変更した。
それ以外でリロードした時は	そのページにとどまったままに変更。