### PR TITLE
ユーザーページの改修

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -35,16 +35,16 @@ nav(class="bg-bleachWhite px-2 sm:px-4 py-2.5 rounded")
       h1(class="text-midnightBlue text-xl font-bold") Graimer
     div
       div(v-if="isLoggedIn")
-        router-link(v-if='windowSize >= 640' to="/users")  
+        router-link(v-if='windowSize >= 640' :to="{name: 'Users', params: { user_id: authStore.uid }}")  
           img(:src="icon" class="mini-avatar ring-2 ring-gray-700")
         div(v-else class="relative")
           button(class="relative z-10 block" @click="isOpen = !isOpen")
             img(:src="icon" class="mini-avatar ring-2 ring-gray-700")
           button(v-show="isOpen" tabindex="-1" class="z-10 fixed inset-0 h-full w-full cursor-default" @click="isOpen = false")
           div(v-show="isOpen"  class="absolute right-0 z-10 mt-2 py-2 w-48 bg-white rounded-lg shadow-xl" @click="isOpen = false")
-            router-link(to="/users" class="block px-4 py-2 text-gray-800 hover:bg-gray-100") ユーザー情報
+            router-link(:to="{name: 'Users', params: { user_id: authStore.uid }}" class="block px-4 py-2 text-gray-800 hover:bg-gray-100") ユーザー情報
             a(class="block cursor-pointer px-4 py-2 text-gray-800 hover:bg-gray-100" @click="authStore.logout()") ログアウト
-            
+
       ul(v-else class="flex text-sm p-2 space-x-2 rounded-lg sm:space-x-8 sm:text-lg sm:font-medium")
         li
           router-link(to="/sign_up" class=" text-midnightBlue hover:text-dustyOrange" :class='{"text-dustyOrange": isSignUpPage}') 新規登録

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -49,7 +49,7 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
-      path: '/users',
+      path: '/users/:user_id',
       name: 'Users',
       component: UserView,
       meta: { requiresAuth: true },

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -21,6 +21,7 @@ import {
   doc,
   getDoc,
   setDoc,
+  updateDoc,
 } from 'firebase/firestore'
 import Icon from '../assets/user_icon.png'
 /* eslint-enable */
@@ -50,6 +51,8 @@ const useAuthStore = defineStore('auth', {
               // database usersを作成
               await setDoc(doc(db, 'users', user.uid), {
                 profile: 'よろしくお願いします。',
+                name: name,
+                icon: '',
                 uid: user.uid,
               })
               await this.setUser(user)
@@ -104,6 +107,13 @@ const useAuthStore = defineStore('auth', {
       const userDocSnap = await getDoc(userDocRef)
       if (userDocSnap.exists()) {
         this.profile = userDocSnap.data().profile
+        // usersDB追加更新
+        if (userDocSnap.data().name === undefined) {
+          await updateDoc(userDocRef, {
+            name: this.name,
+            icon: this.icon,
+          })
+        }
       }
     },
     // TODO canvas store作成

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -51,7 +51,7 @@ const useAuthStore = defineStore('auth', {
               // database usersを作成
               await setDoc(doc(db, 'users', user.uid), {
                 profile: 'よろしくお願いします。',
-                name: name,
+                name,
                 icon: '',
                 uid: user.uid,
               })

--- a/src/views/ProfileSettingsPage.vue
+++ b/src/views/ProfileSettingsPage.vue
@@ -15,6 +15,7 @@ const authUser = getAuth().currentUser!
 const authStore = useAuthStore()
 const icon = ref(authStore.icon)
 const uploadFile = ref(new File([], ''))
+const usersRef = doc(db, 'users', authStore.uid)
 
 const inputText = reactive({
   icon: 'person',
@@ -40,7 +41,7 @@ const saveProfile = () => {
   if (!alertFlag) return
 
   updateFireBase()
-  router.push({ name: 'Users' })
+  router.push({ name: 'Users', params: { user_id: authStore.uid } })
 }
 
 const validate = (): boolean => {
@@ -81,7 +82,6 @@ const updateFireBase = async () => {
 }
 
 const updateProfileText = async () => {
-  const usersRef = doc(db, 'users', authStore.uid)
   await updateDoc(usersRef, {
     profile: textArea.text,
   })
@@ -92,7 +92,10 @@ const updateName = () => {
   updateProfile(authUser, {
     displayName: inputText.text,
   })
-    .then(() => {
+    .then(async () => {
+      await updateDoc(usersRef, {
+        name: inputText.text,
+      })
       authStore.name = inputText.text
     })
     .catch((error) => {
@@ -127,7 +130,10 @@ const updateIcon = () => {
         updateProfile(authUser, {
           photoURL: downloadURL,
         })
-          .then(() => {
+          .then(async () => {
+            await updateDoc(usersRef, {
+              icon: downloadURL,
+            })
             authStore.icon = downloadURL
           })
           .catch((error) => {

--- a/src/views/UsersPage.vue
+++ b/src/views/UsersPage.vue
@@ -1,21 +1,92 @@
 <script setup lang="ts">
-import { storeToRefs } from 'pinia'
+import { ref, watch, onMounted } from 'vue'
 import useAuthStore from '@/stores/auth'
+import { useRoute } from 'vue-router'
+import { db } from '@/firebase/index'
+import {
+  query,
+  doc,
+  getDocs,
+  getDoc,
+  where,
+  collection,
+} from 'firebase/firestore'
+import Icon from '../assets/user_icon.png'
 
-const authStore = useAuthStore()
-const { name, icon, profile } = storeToRefs(useAuthStore())
+const route = useRoute(),
+  authStore = useAuthStore(),
+  name = ref(''),
+  icon = ref(''),
+  profile = ref('')
+
+type Canvas = typeof authStore.canvases
+let canvases: Canvas
+
+onMounted(() => {
+  setProfile()
+})
+
+watch(route, () => {
+  setProfile()
+})
+
+const setProfile = () => {
+  const otherUserUID = String(route.params.user_id)
+  if (authStore.uid !== otherUserUID) {
+    getDoc(doc(db, 'users', otherUserUID))
+      .then((userDocSnap) => {
+        if (userDocSnap.exists()) {
+          name.value = userDocSnap.data().name
+          icon.value =
+            userDocSnap.data().icon === '' ? Icon : userDocSnap.data().icon
+          profile.value = userDocSnap.data().profile
+          // canvas取得
+          setCanvases(otherUserUID)
+        } else {
+          console.log('プロフィール情報が見つかりません')
+          // TODO twitterのように「このアカウントは存在しません」とする
+        }
+      })
+      .catch((error) => {
+        console.log('プロフィール情報の取得に失敗しました：', error)
+      })
+  } else {
+    name.value = authStore.name
+    icon.value = authStore.icon
+    profile.value = authStore.profile
+    canvases = authStore.canvases
+  }
+}
+
+const setCanvases = (otherUserUID: string) => {
+  const canvasQuery = query(
+    collection(db, 'canvas'),
+    where('uid', '==', otherUserUID),
+    where('isShare', '==', true),
+  )
+  getDocs(canvasQuery)
+    .then((querySnapshot) => {
+      querySnapshot.forEach((document) => {
+        const canvasID = document.id
+        canvases[canvasID] = document.data()
+      })
+    })
+    .catch((error) => {
+      console.log(error)
+    })
+}
 </script>
 
 <template lang="pug">
 div(class="grid grid-cols-12 mt-4 sm:mt-8")
   //- left
-  div(class="col-span-3 lg:col-span-2 sm:block hidden")
+  div(v-if="authStore.uid === route.params.user_id" class="col-span-3 lg:col-span-2 sm:block hidden")
     div(class="border rounded-lg p-4")
       ul(class="text-midnightBlue")
         li(class="border-b pb-2")
           router-link(to="users" class="text-dustyOrange block") ユーザー情報
         //- li(class="border-b py-2")
-        //-   a(href="#" class="block") ブックマーク
+        //-   a(href="#" class="block") お気に入り
         //- li(class="border-b py-2")
         //-   a(href="#" class="block") 設定
         li(class="pt-2")
@@ -30,13 +101,13 @@ div(class="grid grid-cols-12 mt-4 sm:mt-8")
         div(class="flex flex-col justify-around text-midnightBlue mt-4 sm:mt-0 sm:ml-4")
           p(class="text-xl lg:text-2xl font-bold") {{ name }}
           p(class="text-xs sm:text-sm  whitespace-pre-wrap") {{ profile }}
-      div(class="col-span-2 absolute sm:static top-4 right-0 mx-auto")
+      div(v-if="authStore.uid === route.params.user_id" class="col-span-2 absolute sm:static top-4 right-0 mx-auto")
         router-link(to="/profile/settings") 
           button(class="focus:outline-none text-white bg-seaPink hover:bg-red-400 focus:ring-4 focus:ring-red-300 font-medium rounded-lg px-3 py-1") 編集
-          
+
     //- bottom
     div(class="my-8 grid gap-4 xl:grid-cols-3 md:grid-cols-2")      
-      div(v-for="(canvas, index) of authStore.canvases" :key="index" class="picture m-auto")
+      div(v-for="(canvas, index) of canvases" :key="index" class="picture m-auto")
         router-link(:to="{name: 'Create', params: { canvas_id: index }}")
           div(class="flex items-center")  
             img(v-if='canvas.image' :src="canvas.image" class="bg-gray-200 rounded-lg border border-gray-500" style="width: 320px; height: 180px")

--- a/src/views/UsersPage.vue
+++ b/src/views/UsersPage.vue
@@ -60,12 +60,12 @@ const setProfile = () => {
         console.log('プロフィール情報の取得に失敗しました：', error)
       })
   } else {
-    authIsReady.value = true
     user.value = {
       name: authStore.name,
       icon: authStore.icon,
       profile: authStore.profile,
     }
+    authIsReady.value = true
     canvases.value = authStore.canvases
   }
 }

--- a/src/views/UsersPage.vue
+++ b/src/views/UsersPage.vue
@@ -42,7 +42,6 @@ const setProfile = () => {
   if (authStore.uid !== otherUserUID) {
     getDoc(doc(db, 'users', otherUserUID))
       .then(async (userDocSnap) => {
-        authIsReady.value = true
         if (userDocSnap.exists()) {
           user.value = {
             name: userDocSnap.data().name,
@@ -50,8 +49,10 @@ const setProfile = () => {
               userDocSnap.data().icon === '' ? Icon : userDocSnap.data().icon,
             profile: userDocSnap.data().profile,
           }
+          authIsReady.value = true
           canvases.value = await setCanvases(otherUserUID)
         } else {
+          authIsReady.value = true
           console.log('プロフィール情報が見つかりません')
         }
       })

--- a/src/views/UsersPage.vue
+++ b/src/views/UsersPage.vue
@@ -48,7 +48,6 @@ const setProfile = () => {
           setCanvases(otherUserUID)
         } else {
           isValidUser.value = false
-          canvases.value = {}
           console.log('プロフィール情報が見つかりません')
         }
       })
@@ -102,7 +101,7 @@ div(class="grid grid-cols-12 mt-4 sm:mt-8")
     div(class="border rounded-lg p-4")
       ul(class="text-midnightBlue")
         li(class="border-b pb-2")
-          router-link(to="users" class="text-dustyOrange block") ユーザー情報
+          router-link(:to="{name: 'Users', params: { user_id: authStore.uid }}" class="text-dustyOrange block") ユーザー情報
         //- li(class="border-b py-2")
         //-   a(href="#" class="block") お気に入り
         //- li(class="border-b py-2")
@@ -112,7 +111,7 @@ div(class="grid grid-cols-12 mt-4 sm:mt-8")
   //- right
   div(:class="userCol()" class="col-span-12")
     //- top
-    div(v-if="isValidUser===true" class="relative sm:static sm:grid sm:grid-cols-12 pb-4 border-b")
+    div(v-if="isValidUser" class="relative sm:static sm:grid sm:grid-cols-12 pb-4 border-b")
       div(class="col-span-10 sm:flex")
         div
           img(:src="icon" class="avatar ring-2 ring-gray-700 ")

--- a/src/views/UsersPage.vue
+++ b/src/views/UsersPage.vue
@@ -15,10 +15,13 @@ import Icon from '../assets/user_icon.png'
 
 const route = useRoute()
 const authStore = useAuthStore()
+
+type Canvases = typeof authStore.canvases
+
 const name = ref('')
 const icon = ref('')
 const profile = ref('')
-const canvases = ref({})
+const canvases: Canvases = ref({})
 const isValidUser = ref()
 
 onMounted(() => {

--- a/src/views/UsersPage.vue
+++ b/src/views/UsersPage.vue
@@ -13,11 +13,11 @@ import {
 } from 'firebase/firestore'
 import Icon from '../assets/user_icon.png'
 
-const route = useRoute(),
-  authStore = useAuthStore(),
-  name = ref(''),
-  icon = ref(''),
-  profile = ref('')
+const route = useRoute()
+const authStore = useAuthStore()
+const name = ref('')
+const icon = ref('')
+const profile = ref('')
 
 type Canvas = typeof authStore.canvases
 let canvases: Canvas


### PR DESCRIPTION
### 関連している Issue / 目的

他ユーザーのProfileを閲覧できるようにする

### 達成条件

urlのパスに他ユーザーのuidが入力されたら、
データを取得し表示する

### 実装の概要 / この PR の対応範囲

- userページのurlにパスを追加。追加に伴う、header urlの変更
- user databaseにnameとiconを追加。ログイン時に自動で追加するよう変更。新規も！
- 上記追加に伴う、プロフィール設定ページの変更
- urlのパスに他ユーザーのuidが入力されたら、データを取得しProfileを表示
- ユーザーがいない場合、「このアカウントは存在しません」と表示
- 他ユーザーのcanvasの取得

### その他情報（スクリーンショット等）

- その他抜けがあったら教えて下さい

![スクリーンショット 2023-03-28 16 23 43](https://user-images.githubusercontent.com/68400191/228160098-caca0aed-adc0-4732-8890-684c6c93dc4b.png)

![スクリーンショット 2023-03-28 16 24 05](https://user-images.githubusercontent.com/68400191/228160173-084ef116-afc3-47c3-adcf-7e4649f7f3f5.png)