### PR TITLE
fix: vite.config.ts base url

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import vue from '@vitejs/plugin-vue'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
-  base: './',
+  base: '/',
   build: {
     outDir: resolve(__dirname, 'docs'),
     assetsDir: './',


### PR DESCRIPTION
目的
動的パラメーターのページをロードすると何も表示されなくなるバグを修正

実装内容
vite.config.tsのbase urlを./から/に変更