### PR TITLE
fix: await onSnapshot

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -98,7 +98,7 @@ async function autoLogin(to: RouteLocationNormalized) {
         // ユーザーがアップロードした画像を取得
         await loadUserImageStorage(user.uid)
         // 使用されていない画像をStorageとFirestoreから削除
-        await deleteImageFromStorageWithLogin(user.uid)
+        deleteImageFromStorageWithLogin(user.uid)
         if (to.name === 'Home' || to.meta.requiresAuth === false) {
           await forceToWorksPage()
         }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -87,14 +87,18 @@ async function autoLogin(to: RouteLocationNormalized) {
   const authStore = useAuthStore()
   const canvasStore = useStoreCanvas()
   const { isLoggedIn } = authStore
+  const { loadUserImageStorage, deleteImageFromStorageWithLogin } =
+    useStoreUserImage()
   /* eslint-disable */
   return new Promise<void>((resolve) => {
     onAuthStateChanged(auth, async (user) => {
       if (user != null) {
         await authStore.setUser(user)
         await canvasStore.getCanvases(user.uid)
-        const { loadUserImageStorage } = useStoreUserImage()
-        loadUserImageStorage()
+        // ユーザーがアップロードした画像を取得
+        await loadUserImageStorage(user.uid)
+        // 使用されていない画像をStorageとFirestoreから削除
+        await deleteImageFromStorageWithLogin(user.uid)
         if (to.name === 'Home' || to.meta.requiresAuth === false) {
           await forceToWorksPage()
         }

--- a/src/stores/canvas.ts
+++ b/src/stores/canvas.ts
@@ -22,8 +22,7 @@ const useStoreCanvas = defineStore({
         where('uid', '==', uid),
       )
       // リアルタイムでアップデートを取得する
-      // eslint-disable-next-line no-return-await
-      return await new Promise<void>((resolve) => {
+      const promise = new Promise<void>((resolve) => {
         onSnapshot(
           canvasQuery,
           (querySnapshot) => {
@@ -40,6 +39,7 @@ const useStoreCanvas = defineStore({
           },
         )
       })
+      await promise
     },
   },
 })

--- a/src/stores/canvas.ts
+++ b/src/stores/canvas.ts
@@ -21,15 +21,24 @@ const useStoreCanvas = defineStore({
         collection(db, 'canvas'),
         where('uid', '==', uid),
       )
-
       // リアルタイムでアップデートを取得する
-      onSnapshot(canvasQuery, (querySnapshot) => {
-        const canvases = {} as DocumentData
-        querySnapshot.forEach((document) => {
-          const canvasID = document.id
-          canvases[canvasID] = document.data()
-        })
-        this.canvases = canvases
+      // eslint-disable-next-line no-return-await
+      return await new Promise<void>((resolve) => {
+        onSnapshot(
+          canvasQuery,
+          (querySnapshot) => {
+            const canvases = {} as DocumentData
+            querySnapshot.forEach((document) => {
+              const canvasID = document.id
+              canvases[canvasID] = document.data()
+            })
+            this.canvases = canvases
+            resolve()
+          },
+          (error) => {
+            console.log(error)
+          },
+        )
       })
     },
   },

--- a/src/stores/userImage.ts
+++ b/src/stores/userImage.ts
@@ -264,9 +264,8 @@ const useStoreUserImage = defineStore({
     async loadUserImageStorage(uid: string) {
       const docRef = doc(db, 'userImageStorage', uid)
 
-      // onsnapshotでローカルのuserImageStorageを更新する
-      // eslint-disable-next-line no-return-await
-      return await new Promise<void>((resolve) => {
+      // リアルタイムでアップデートを取得する
+      const promise = new Promise<void>((resolve) => {
         onSnapshot(
           docRef,
           (docSnap) => {
@@ -282,6 +281,7 @@ const useStoreUserImage = defineStore({
           },
         )
       })
+      await promise
     },
   },
 


### PR DESCRIPTION
### 関連している Issue / 目的
#95 

### 達成条件
プロフィールページのキャンバス＋ユーザーの画像を読み込む時のonSnapshotの処理を修正した。

### 実装の概要 / この PR の対応範囲
onSnapshotをPromiseを返す関数でラップすることで、awaitで処理待ちすることができるようにした。

### 不安に思っていること
Promiseの使い方、非同期処理
