### PR TITLE
Fix/refactor create page

### DIFF
--- a/src/stores/konva/image.ts
+++ b/src/stores/konva/image.ts
@@ -74,7 +74,6 @@ const useStoreImage = defineStore({
 
     // KonvaImageをFirestoreCanvasImageに変換
     changeKonvaImagesToFirestoreCanvasImages(konvaImages: KonvaImage[]) {
-      console.log('changeKonvaImagesToFirestoreCanvasImages')
       const firestoreCanvasImagesArray = [] as FirestoreCanvasImage[]
       konvaImages?.forEach((konvaImage: KonvaImage) => {
         firestoreCanvasImagesArray.push({

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -31,7 +31,7 @@ type KonvaEventObject<T> = Konva.KonvaEventObject<T>
 const StorageReference = storageRef(storage, '')
 
 const { mode } = storeToRefs(useStoreMode())
-const { configKonva, canvasHistory, historyStep } = storeToRefs(useStoreStage())
+const { configKonva, canvasHistory } = storeToRefs(useStoreStage())
 const { lines } = storeToRefs(useStoreLine())
 const { texts, isEditing, isFontLoaded } = storeToRefs(useStoreText())
 const { uid } = storeToRefs(useAuthStore())
@@ -182,7 +182,7 @@ onMounted(async () => {
         images: _.cloneDeep(konvaImages.value),
       },
     ]
-    // 編集開始時のkonvaImagesをセット（画像の使用状況追跡のため）
+    // 編集開始時のkonvaImagesをセット(画像の使用状況追跡のため)
     firstKonvaImages.value = _.cloneDeep(konvaImages.value)
   }
 })
@@ -196,9 +196,8 @@ onUnmounted(() => {
     handleKeyDownSelectedNodeDelete(e)
   })
 
-  // canvasHistoryのリセット
-  historyStep.value = 0
-  canvasHistory.value = [{ lines: [], texts: [], images: [] }]
+  // 履歴(canvasHistory)のリセット
+  useStoreStage().$reset()
 })
 
 router.beforeEach(() => {

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -133,7 +133,7 @@ const changeModeByShortCut = (e: KeyboardEvent) => {
   // redo
 }
 
-onMounted(async () => {
+onMounted(() => {
   // 初期化
   useStoreMode().$reset()
   useStoreLine().$reset()

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -195,9 +195,6 @@ onUnmounted(() => {
     changeModeByShortCut(e)
     handleKeyDownSelectedNodeDelete(e)
   })
-
-  // 履歴(canvasHistory)のリセット
-  useStoreStage().$reset()
 })
 
 router.beforeEach(() => {

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -157,8 +157,8 @@ onMounted(() => {
   if (canvases.value[canvasId.value] !== undefined) {
     const canvas = canvases.value[canvasId.value]
     // キャンバスの各プロパティをセット
-    lines.value = canvas.lines
-    texts.value = canvas.texts
+    lines.value = _.cloneDeep(canvas.lines)
+    texts.value = _.cloneDeep(canvas.texts)
     konvaImages.value = changeFirestoreCanvasImagesToKonvaImages(
       canvas.konvaImages,
     )

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -29,7 +29,7 @@ import _ from 'lodash'
 const { mode } = storeToRefs(useStoreMode())
 const { configKonva, canvasHistory } = storeToRefs(useStoreStage())
 const { lines } = storeToRefs(useStoreLine())
-const { texts, isEditing, isFontLoaded } = storeToRefs(useStoreText())
+const { texts, isEditing } = storeToRefs(useStoreText())
 const { uid } = storeToRefs(useAuthStore())
 const { canvases } = storeToRefs(useStoreCanvas())
 const { konvaImages, firstKonvaImages } = storeToRefs(useStoreImage())
@@ -140,6 +140,7 @@ onMounted(() => {
   useStoreText().$reset()
   useStoreImage().$reset()
   useStoreStage().$reset()
+  useStoreTransformer().$reset()
 
   // stageのリサイズ
   fitStageIntoParentContainer(stageParentDiv.value)
@@ -151,24 +152,6 @@ onMounted(() => {
     changeModeByShortCut(e)
     handleKeyDownSelectedNodeDelete(e)
   })
-
-  // Font読み込み
-  // TODO:まれに読み込みが完了しない場合があるため、要検証
-  if (!isFontLoaded.value) {
-    WebFont.load({
-      google: {
-        families: fontFamilyList,
-      },
-      loading: () => {
-        console.log('font is loading')
-      },
-      // 全てWebフォントの読み込みが完了したときに発火
-      active: () => {
-        isFontLoaded.value = true
-        console.log('fonts is loaded!')
-      },
-    })
-  }
 
   // キャンバスが既にある場合
   if (canvases.value[canvasId.value] !== undefined) {
@@ -191,6 +174,20 @@ onMounted(() => {
     // 編集開始時のkonvaImagesをセット(画像の使用状況追跡のため)
     firstKonvaImages.value = _.cloneDeep(konvaImages.value)
   }
+
+  // Font読み込み(キャンバスのセット後に読み込む必要あり)
+  WebFont.load({
+    google: {
+      families: fontFamilyList,
+    },
+    loading: () => {
+      console.log('font is loading')
+    },
+    // 全てWebフォントの読み込みが完了したときに発火
+    active: () => {
+      console.log('fonts is loaded!')
+    },
+  })
 })
 
 onUnmounted(() => {


### PR DESCRIPTION
### 関連している Issue / 目的
CreatePage.vueのリファクタリング

### 実装の概要 / この PR の対応範囲
- onMounted時のキャンバスの初期化をpiniaの$resetメソッドに置き換えた。
- saveCanvasのサムネイル保存の修正
- 適宜、コメントを挿入

### 重点的にレビューしてほしいところ
サムネイルを保存するsaveImage()をgenerateAndSaveThumbnail()に変更しました。
以前はdataurlを一度Fileオブジェクトに変換してから、storageにアップロードしていましたが、
今回はdataurlを直接storageにアップロードするようにしました。
