### PR TITLE
Fix/refactor stores

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { storeToRefs } from 'pinia'
-import useAuthStore from '@/stores/auth'
-import { useRoute, useRouter } from 'vue-router'
 import { ref, onMounted } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useRoute, useRouter } from 'vue-router'
+import useAuthStore from '@/stores/auth'
 
 const route = useRoute()
 const router = useRouter()

--- a/src/components/SubToolMenu.vue
+++ b/src/components/SubToolMenu.vue
@@ -267,7 +267,7 @@ div(v-else-if="mode === 'image'" class="flex justify-center items-center bg-gray
     //- image list
     div(class="bg-slate-50 flex-1 grid grid-cols-3 h-52 w-full overflow-y-scroll rounded-lg ml-2")
       div(v-for="image of getToolbarImages" :key="image.id" class="relative flex justify-center items-center")
-        button(type="button" class="flex justify-center items-center absolute top-0 right-0 w-9 h-9 rounded-full bg-slate-200 hover:bg-slate-300 m-1" @click="async () => {await deleteImageFromToolbar(image);}") ✕
+        button(type="button" class="flex justify-center items-center absolute top-0 right-0 w-9 h-9 rounded-full bg-slate-200 hover:bg-slate-300 m-1" @click="deleteImageFromToolbar(image)") ✕
         img(:id="image.id" :src="image.storageURL" class="w-full aspect-auto col-span-1 p-2 hover:cursor-grab active:cursor-grabbing" @dragstart="(e) => {setDragImageUrlAndId(e);}")
 </template>
 

--- a/src/components/SubToolMenu.vue
+++ b/src/components/SubToolMenu.vue
@@ -231,7 +231,7 @@ watch(fill, () => {
 
 <template lang="pug">
 //- pen
-div(v-if="mode === 'pen'" class="flex justify-center items-center bg-gray-200 rounded-lg border border-gray-400 shadow-md pt-2 pb-3 px-2 absolute -top-3/4 max-w-screen-md h-16")
+div(v-show="mode === 'pen'" class="flex justify-center items-center bg-gray-200 rounded-lg border border-gray-400 shadow-md pt-2 pb-3 px-2 absolute -top-3/4 max-w-screen-md h-16")
   LineStyleSelect
   //- Not use Hand
   div(class="px-2")
@@ -247,11 +247,11 @@ div(v-if="mode === 'pen'" class="flex justify-center items-center bg-gray-200 ro
     StrokeWidthRange
 //- eraser
 div(
-  v-else-if="mode === 'eraser'"
+  v-show="mode === 'eraser'"
   class="flex justify-center items-center bg-gray-200 rounded-lg border border-gray-400 shadow-md pt-2 pb-3 px-2 absolute -top-3/4 max-w-screen-md h-16")
   StrokeWidthRange
 //- text
-div(v-else-if="mode === 'text'" class="flex justify-center items-center bg-gray-200 rounded-lg border border-gray-400 shadow-md pt-2 pb-3 px-2 absolute -top-3/4 max-w-screen-md h-16")
+div(v-show="mode === 'text'" class="flex justify-center items-center bg-gray-200 rounded-lg border border-gray-400 shadow-md pt-2 pb-3 px-2 absolute -top-3/4 max-w-screen-md h-16")
   FontSizeSelect
   FontFamilySelect
   TextAlignmentSelect
@@ -260,7 +260,7 @@ div(v-else-if="mode === 'text'" class="flex justify-center items-center bg-gray-
     :key="color.name" :color="color"
     :colors="textColors" :store-color="fill" @toggle-picker-active="(color:string) => {setTextColor(color);setTextOptionValue('textFillColor', color)}")
 //- image
-div(v-else-if="mode === 'image'" class="flex justify-center items-center bg-gray-200 rounded-lg border border-gray-400 shadow-md pt-2 pb-6 px-2 absolute bottom-3/4 max-w-screen-sm w-screen")
+div(v-show="mode === 'image'" class="flex justify-center items-center bg-gray-200 rounded-lg border border-gray-400 shadow-md pt-2 pb-6 px-2 absolute bottom-3/4 max-w-screen-sm w-screen")
   div(class="flex items-end h-52 w-full")
     label(class="upload-label bg-neutral inline-block cursor-pointer rounded-lg py-2 px-5 text-white text-lg") ファイルを選択
       input(type="file" class="bg-white file-input file-input-bordered file-input-sm min-w-min rounded-lg" accept=".png, .jpeg, .jpg" @change="addImageToToolbar")

--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -2,23 +2,22 @@
 import { reactive, toRefs } from 'vue'
 import { storeToRefs } from 'pinia'
 import Konva from 'konva'
+import SubToolMenu from '@/components/SubToolMenu.vue'
+import UndoRedoButton from '@/components/ToolBar/UndoRedoButton.vue'
 import useStoreMode, { type Mode } from '@/stores/mode'
 import useStoreLine from '@/stores/konva/line'
 import useStoreText from '@/stores/konva/text'
 import useStoreImage from '@/stores/konva/image'
 import useStoreTransformer from '@/stores/konva/transformer'
-import useStoreStage from '@/stores/konva/stage'
-import SubToolMenu from '@/components/SubToolMenu.vue'
-import UndoRedoButton from '@/components/ToolBar/UndoRedoButton.vue'
+import useStoreHistory from '@/stores/konva/history'
 
 interface Props {
   stage: Konva.Stage
-  stageParentDiv: HTMLDivElement
   saveCanvas: () => Promise<void>
 }
 
 const props = defineProps<Props>()
-const { stage, stageParentDiv } = toRefs(props)
+const { stage } = toRefs(props)
 
 const { mode } = storeToRefs(useStoreMode())
 const { setMode } = useStoreMode()
@@ -26,7 +25,6 @@ const { setLineStyle, setGlobalCompositeOperation, deleteLines } =
   useStoreLine()
 const { deleteTexts } = useStoreText()
 const { deleteImages } = useStoreImage()
-const { fitStageIntoParentContainer } = useStoreStage()
 
 const resetCanvas = async () => {
   // delete
@@ -37,9 +35,7 @@ const resetCanvas = async () => {
   // キャンバスの状態をfirebaseに保存
   props.saveCanvas()
   // reset history
-  useStoreStage().$reset()
-  // stageのリサイズ
-  fitStageIntoParentContainer(stageParentDiv.value)
+  useStoreHistory().$reset()
 }
 
 // キャンバスをPNGでダウンロード

--- a/src/components/ToolBar/TextAlignmentSelect.vue
+++ b/src/components/ToolBar/TextAlignmentSelect.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import useStoreText from '@/stores/konva/text'
 import { reactive } from 'vue'
+import useStoreText from '@/stores/konva/text'
 
 const { setTextOptionValue, setTextAlign } = useStoreText()
 

--- a/src/components/ToolBar/UndoRedoButton.vue
+++ b/src/components/ToolBar/UndoRedoButton.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { reactive } from 'vue'
-import useStoreStage from '@/stores/konva/stage'
+import useStoreHistory from '@/stores/konva/history'
 
-const { handleUndo, handleRedo } = useStoreStage()
+const { handleUndo, handleRedo } = useStoreHistory()
 
 const undoRedoArray = reactive([
   {

--- a/src/components/UserCursor.vue
+++ b/src/components/UserCursor.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// import Konva from 'konva'
 import { storeToRefs } from 'pinia'
 import useStoreMode from '@/stores/mode'
 import useStoreLine from '@/stores/konva/line'

--- a/src/stores/konva/history.ts
+++ b/src/stores/konva/history.ts
@@ -12,57 +12,14 @@ interface History {
   images: KonvaImage[]
 }
 
-const useStoreStage = defineStore({
-  id: 'stage',
+const useStoreHistory = defineStore({
+  id: 'history',
   state: () => ({
-    configKonva: {
-      size: {
-        width: window.innerWidth,
-        height: window.innerWidth,
-      },
-      scale: {
-        x: 1,
-        y: 1,
-      },
-    },
     historyStep: 0,
     canvasHistory: [{ lines: [], texts: [], images: [] }] as History[],
   }),
 
   actions: {
-    fitStageIntoParentContainer(container: HTMLDivElement) {
-      // Fixed stage size
-      const SCENE_BASE_WIDTH = 896
-      const SCENE_BASE_HEIGHT = 504
-
-      // Max upscale
-      const SCENE_MAX_WIDTH = 1280
-      const SCENE_MAX_HEIGHT = 720
-
-      if (container === null) return
-
-      const stageWidth =
-        container.offsetWidth % 2 !== 0
-          ? container.offsetWidth - 1
-          : container.offsetWidth
-
-      this.configKonva.size = {
-        width: stageWidth,
-        height: (stageWidth * 9) / 16, // aspect-ratio
-      }
-
-      const scaleX =
-        Math.min(this.configKonva.size.width, SCENE_MAX_WIDTH) /
-        SCENE_BASE_WIDTH
-
-      const scaleY =
-        Math.min(this.configKonva.size.height, SCENE_MAX_HEIGHT) /
-        SCENE_BASE_HEIGHT
-
-      const minRatio = Math.min(scaleX, scaleY)
-      this.configKonva.scale = { x: minRatio, y: minRatio }
-    },
-
     handleEventEndSaveHistory() {
       const { lines } = storeToRefs(useStoreLine())
       const { texts } = storeToRefs(useStoreText())
@@ -128,4 +85,4 @@ const useStoreStage = defineStore({
   },
 })
 
-export default useStoreStage
+export default useStoreHistory

--- a/src/stores/konva/image.ts
+++ b/src/stores/konva/image.ts
@@ -123,9 +123,12 @@ const useStoreImage = defineStore({
       imageObj.src = this.dragUrl
       imageObj.crossOrigin = 'anonymous'
       imageObj.onload = () => {
+        // maxCanvasRatio:キャンバスに対して設定した倍率の大きさの画像を描画できる。
+        const maxCanvasRatio = 0.9
         // stage
-        const maxImageWidth = (stage.width() / stage.scaleX()) * 0.8
-        const maxImageHeight = (stage.height() / stage.scaleY()) * 0.8
+        const maxImageWidth = (stage.width() / stage.scaleX()) * maxCanvasRatio
+        const maxImageHeight =
+          (stage.height() / stage.scaleY()) * maxCanvasRatio
         // image
         let imageWidth = imageObj.width
         let imageHeight = imageObj.height

--- a/src/stores/konva/image.ts
+++ b/src/stores/konva/image.ts
@@ -1,9 +1,9 @@
+/* eslint-disable import/no-cycle */
 import Konva from 'konva'
 import { nanoid } from 'nanoid'
 import { defineStore } from 'pinia'
 import useStoreMode from '@/stores/mode'
-// eslint-disable-next-line import/no-cycle
-import useStoreStage from '@/stores/konva/stage'
+import useStoreHistory from '@/stores/konva/history'
 
 export interface KonvaImage {
   id: string
@@ -157,7 +157,7 @@ const useStoreImage = defineStore({
         },
       ])
 
-      useStoreStage().handleEventEndSaveHistory()
+      useStoreHistory().handleEventEndSaveHistory()
 
       // モード終了し、サブメニューを閉じる
       useStoreMode().$reset()
@@ -175,7 +175,7 @@ const useStoreImage = defineStore({
         text.x = shape.x()
         text.y = shape.y()
       }
-      useStoreStage().handleEventEndSaveHistory()
+      useStoreHistory().handleEventEndSaveHistory()
     },
   },
 })

--- a/src/stores/konva/image.ts
+++ b/src/stores/konva/image.ts
@@ -55,7 +55,10 @@ const useStoreImage = defineStore({
             id: firestoreCanvasImage.id,
             imageId: firestoreCanvasImage.imageId,
             name: firestoreCanvasImage.name,
-            image: this.changeURLToImageElement(firestoreCanvasImage.image),
+            image: this.changeURLToImageElement(
+              firestoreCanvasImage.image,
+              firestoreCanvasImage.id,
+            ),
             x: firestoreCanvasImage.x,
             y: firestoreCanvasImage.y,
             width: firestoreCanvasImage.width,
@@ -91,8 +94,9 @@ const useStoreImage = defineStore({
     },
 
     // image urlをimage elementに変換する
-    changeURLToImageElement(url: string): HTMLImageElement {
+    changeURLToImageElement(url: string, id: string): HTMLImageElement {
       const imageObj = new Image()
+      imageObj.id = id
       imageObj.src = url
       imageObj.crossOrigin = 'anonymous'
       return imageObj

--- a/src/stores/konva/image.ts
+++ b/src/stores/konva/image.ts
@@ -123,13 +123,20 @@ const useStoreImage = defineStore({
       imageObj.src = this.dragUrl
       imageObj.crossOrigin = 'anonymous'
       imageObj.onload = () => {
-        // 画像のリサイズ
-        const originalWidth = imageObj.width
-        // widthは100pxに縮小するかそのまま
-        imageObj.width = Math.min(originalWidth, 100)
-        // 100pxに縮小したらheightも変更する
-        if (imageObj.width === 100) {
-          imageObj.height = (imageObj.height * 100) / originalWidth
+        // stage
+        const maxImageWidth = (stage.width() / stage.scaleX()) * 0.8
+        const maxImageHeight = (stage.height() / stage.scaleY()) * 0.8
+        // image
+        let imageWidth = imageObj.width
+        let imageHeight = imageObj.height
+
+        if (imageWidth > maxImageWidth || imageHeight > maxImageHeight) {
+          const ratio = Math.min(
+            maxImageWidth / imageWidth,
+            maxImageHeight / imageHeight,
+          )
+          imageWidth *= ratio
+          imageHeight *= ratio
         }
 
         this.konvaImages = this.konvaImages.concat([
@@ -138,10 +145,10 @@ const useStoreImage = defineStore({
             imageId: imageObj.id,
             name: 'image',
             image: imageObj,
-            x: relativePointerPosition.x - imageObj.width / 2,
-            y: relativePointerPosition.y - imageObj.height / 2,
-            width: imageObj.width,
-            height: imageObj.height,
+            x: relativePointerPosition.x - imageWidth / 2,
+            y: relativePointerPosition.y - imageHeight / 2,
+            width: imageWidth,
+            height: imageHeight,
             rotation: 0,
             scaleX: 1,
             scaleY: 1,

--- a/src/stores/konva/image.ts
+++ b/src/stores/konva/image.ts
@@ -57,7 +57,7 @@ const useStoreImage = defineStore({
             name: firestoreCanvasImage.name,
             image: this.changeURLToImageElement(
               firestoreCanvasImage.image,
-              firestoreCanvasImage.id,
+              firestoreCanvasImage.imageId,
             ),
             x: firestoreCanvasImage.x,
             y: firestoreCanvasImage.y,
@@ -94,9 +94,9 @@ const useStoreImage = defineStore({
     },
 
     // image urlをimage elementに変換する
-    changeURLToImageElement(url: string, id: string): HTMLImageElement {
+    changeURLToImageElement(url: string, imageId: string): HTMLImageElement {
       const imageObj = new Image()
-      imageObj.id = id
+      imageObj.id = imageId
       imageObj.src = url
       imageObj.crossOrigin = 'anonymous'
       return imageObj

--- a/src/stores/konva/line.ts
+++ b/src/stores/konva/line.ts
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia'
 import Konva from 'konva'
 import { nanoid } from 'nanoid'
 import useStoreMode from '@/stores/mode'
-import useStoreStage from '@/stores/konva/stage'
+import useStoreHistory from '@/stores/konva/history'
 
 export interface Points {
   id: string
@@ -117,14 +117,14 @@ const useStoreLine = defineStore({
       // modeがpenかeraserでないならskip
       if (mode !== 'pen' && mode !== 'eraser') return
       this.isDrawing = false
-      useStoreStage().handleEventEndSaveHistory()
+      useStoreHistory().handleEventEndSaveHistory()
     },
 
     handleLineMouseLeave() {
       // 描画中にキャンバスからマウスが外れたら、描画終了
       if (!this.isDrawing) return
       this.isDrawing = false
-      useStoreStage().handleEventEndSaveHistory()
+      useStoreHistory().handleEventEndSaveHistory()
     },
   },
 })

--- a/src/stores/konva/stage.ts
+++ b/src/stores/konva/stage.ts
@@ -17,7 +17,7 @@ const useStoreStage = defineStore({
 
   actions: {
     // Stageのリサイズ
-    fitStageIntoParentContainer(stageParentDiv: HTMLDivElement) {
+    fitStageIntoParentContainer(container: HTMLDivElement) {
       // Fixed stage size
       const SCENE_BASE_WIDTH = 896
       const SCENE_BASE_HEIGHT = 504
@@ -25,7 +25,7 @@ const useStoreStage = defineStore({
       // Max upscale
       const SCENE_MAX_WIDTH = 1280
       const SCENE_MAX_HEIGHT = 720
-      const container = stageParentDiv
+
       if (container === null) return
 
       const stageWidth =

--- a/src/stores/konva/stage.ts
+++ b/src/stores/konva/stage.ts
@@ -1,0 +1,55 @@
+import { defineStore } from 'pinia'
+
+const useStoreStage = defineStore({
+  id: 'stage',
+  state: () => ({
+    configKonva: {
+      size: {
+        width: window.innerWidth,
+        height: window.innerWidth,
+      },
+      scale: {
+        x: 1,
+        y: 1,
+      },
+    },
+  }),
+
+  actions: {
+    // Stageのリサイズ
+    fitStageIntoParentContainer(stageParentDiv: HTMLDivElement) {
+      // Fixed stage size
+      const SCENE_BASE_WIDTH = 896
+      const SCENE_BASE_HEIGHT = 504
+
+      // Max upscale
+      const SCENE_MAX_WIDTH = 1280
+      const SCENE_MAX_HEIGHT = 720
+      const container = stageParentDiv
+      if (container === null) return
+
+      const stageWidth =
+        container.offsetWidth % 2 !== 0
+          ? container.offsetWidth - 1
+          : container.offsetWidth
+
+      this.configKonva.size = {
+        width: stageWidth,
+        height: (stageWidth * 9) / 16, // aspect-ratio
+      }
+
+      const scaleX =
+        Math.min(this.configKonva.size.width, SCENE_MAX_WIDTH) /
+        SCENE_BASE_WIDTH
+
+      const scaleY =
+        Math.min(this.configKonva.size.height, SCENE_MAX_HEIGHT) /
+        SCENE_BASE_HEIGHT
+
+      const minRatio = Math.min(scaleX, scaleY)
+      this.configKonva.scale = { x: minRatio, y: minRatio }
+    },
+  },
+})
+
+export default useStoreStage

--- a/src/stores/konva/text.ts
+++ b/src/stores/konva/text.ts
@@ -3,7 +3,7 @@ import { defineStore, storeToRefs } from 'pinia'
 import { nanoid } from 'nanoid'
 import Konva from 'konva'
 import useStoreMode from '@/stores/mode'
-import useStoreStage from '@/stores/konva/stage'
+import useStoreHistory from '@/stores/konva/history'
 import useStoreTransformer from '@/stores/konva/transformer'
 
 type FontStyle = 'normal' | 'bold' | 'italic' | 'italic bold'
@@ -92,7 +92,7 @@ const useStoreText = defineStore({
           name: 'text',
         },
       ]
-      useStoreStage().handleEventEndSaveHistory()
+      useStoreHistory().handleEventEndSaveHistory()
     },
 
     setTextOptionValue(option: string, value: string | TextAlign) {
@@ -115,7 +115,7 @@ const useStoreText = defineStore({
           default:
             break
         }
-        useStoreStage().handleEventEndSaveHistory()
+        useStoreHistory().handleEventEndSaveHistory()
       }
     },
 
@@ -249,7 +249,7 @@ const useStoreText = defineStore({
         this.removeTextarea(textNode, transformerNode, textarea)
         // 編集終了
         this.isEditing = false
-        useStoreStage().handleEventEndSaveHistory()
+        useStoreHistory().handleEventEndSaveHistory()
       })
     },
 
@@ -272,7 +272,7 @@ const useStoreText = defineStore({
         text.x = shape.x()
         text.y = shape.y()
       }
-      useStoreStage().handleEventEndSaveHistory()
+      useStoreHistory().handleEventEndSaveHistory()
     },
   },
 })

--- a/src/stores/konva/transformer.ts
+++ b/src/stores/konva/transformer.ts
@@ -4,7 +4,7 @@ import { defineStore, storeToRefs } from 'pinia'
 import useStoreMode from '@/stores/mode'
 import useStoreText from '@/stores/konva/text'
 import useStoreImage from '@/stores/konva/image'
-import useStoreStage from '@/stores/konva/stage'
+import useStoreHistory from '@/stores/konva/history'
 
 const useStoreTransformer = defineStore({
   id: 'transformer',
@@ -293,7 +293,7 @@ const useStoreTransformer = defineStore({
           image.scaleY = shape.scaleY()
         }
       }
-      useStoreStage().handleEventEndSaveHistory()
+      useStoreHistory().handleEventEndSaveHistory()
     },
 
     // keydownで選択中の要素を削除
@@ -321,7 +321,7 @@ const useStoreTransformer = defineStore({
           )
           this.$reset()
         }
-        useStoreStage().handleEventEndSaveHistory()
+        useStoreHistory().handleEventEndSaveHistory()
       }
     },
   },

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -74,7 +74,7 @@ const {
 const {
   changeKonvaImagesToFirestoreCanvasImages,
   changeFirestoreCanvasImagesToKonvaImages,
-  setImages,
+  setImagesOnCanvas,
   handleImageDragEnd,
 } = useStoreImage()
 
@@ -394,7 +394,7 @@ div(class="flex justify-center items-center my-4")
     span(class="material-symbols-outlined") done
 
 div(class="m-auto border-4 border-orange-100 max-w-screen-xl my-4")
-  div(ref="stageParentDiv" class="bg-white w-full" @drop="(e) => {setImages(e, stage, canvasId)}" @dragover="(e) => {e.preventDefault();}")
+  div(ref="stageParentDiv" class="bg-white w-full" @drop="(e) => {setImagesOnCanvas(e, stage)}" @dragover.prevent)
     v-stage(
       ref="stage"
       :draggable="mode === 'hand'"

--- a/src/views/LoginPage.vue
+++ b/src/views/LoginPage.vue
@@ -2,7 +2,7 @@
 import { reactive } from 'vue'
 import router from '@/router/index'
 import useAuthStore from '@/stores/auth'
-// import { InputTextType } from '@/types/index'
+
 interface InputTextType {
   icon: string
   inputType: string

--- a/src/views/SignUpPage.vue
+++ b/src/views/SignUpPage.vue
@@ -2,7 +2,7 @@
 import { reactive } from 'vue'
 import router from '@/router/index'
 import useAuthStore from '@/stores/auth'
-// import { InputTextType } from '@/types/index'
+
 interface InputTextType {
   icon: string
   inputType: string


### PR DESCRIPTION
### 関連している Issue / 目的
storeのリファクター

### 実装の概要 / この PR の対応範囲
- store/image.ts
ツールバーの画像をキャンバスにdropした時の読み込みの挙動を修正。
- store/history.ts
store/stage.tsを削除して、historyのみをstore/history.tsで管理することにした。
それに伴い、各ファイルでuseStoreStage→useStoreHistoryに修正。
Stageの状態であるstageConfigはCreatePage.vueで管理することにした。
- SubToolMenu.vue
サブツールメニューの表示をv-ifではなくv-showで切り替えるようにした。
（ツールバーのユーザー画像の読み込みが表示のたびにされなくて済む）
- 各ファイルのimportの整理