### PR TITLE
feat: undo redo shortcut

### DIFF
--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -27,6 +27,9 @@ const { setLineStyle, setGlobalCompositeOperation, deleteLines } =
 const { deleteTexts } = useStoreText()
 const { deleteImages } = useStoreImage()
 
+const ua = window.navigator.userAgent.toLowerCase()
+const isWinOS = ua.indexOf('windows nt') !== -1
+
 const resetCanvas = async () => {
   // delete
   deleteLines()
@@ -78,7 +81,7 @@ const toolArray: ToolArray[] = reactive([
     icon: 'auto_fix_normal',
     mode: 'eraser',
     tooltip: 'Eraser',
-    shortcut: 'Shift + Backspace',
+    shortcut: `Shift + ${isWinOS ? 'BS' : 'Del'}`,
     event: () => {
       setMode('eraser')
       setLineStyle('normal')

--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -78,7 +78,7 @@ const toolArray: ToolArray[] = reactive([
     icon: 'auto_fix_normal',
     mode: 'eraser',
     tooltip: 'Eraser',
-    shortcut: 'Shift + Del',
+    shortcut: 'Shift + Backspace',
     event: () => {
       setMode('eraser')
       setLineStyle('normal')

--- a/src/components/ToolBar/UndoRedoButton.vue
+++ b/src/components/ToolBar/UndoRedoButton.vue
@@ -5,17 +5,23 @@ import type { UndoRedoArray } from '@/types/index'
 
 const { handleUndo, handleRedo } = useStoreHistory()
 
+const ua = window.navigator.userAgent.toLowerCase()
+
 const undoRedoArray: UndoRedoArray[] = reactive([
   {
     icon: 'undo',
-    tooltip: 'Undo : Ctrl + Z',
+    tooltip: `Undo : ${
+      ua.indexOf('windows nt') !== -1 ? 'Ctrl + Z' : 'Command + Z'
+    }`,
     onClick: () => {
       handleUndo()
     },
   },
   {
     icon: 'redo',
-    tooltip: 'Redo : Ctrl + Y',
+    tooltip: `Redo : ${
+      ua.indexOf('windows nt') !== -1 ? 'Ctrl + Y' : 'Command + Y'
+    }`,
     onClick: () => {
       handleRedo()
     },

--- a/src/components/ToolBar/UndoRedoButton.vue
+++ b/src/components/ToolBar/UndoRedoButton.vue
@@ -18,7 +18,7 @@ const undoRedoArray: UndoRedoArray[] = reactive([
   },
   {
     icon: 'redo',
-    tooltip: `Redo : ${isWinOS ? 'Ctrl + Y' : 'Cmd + Shift + Y'}`,
+    tooltip: `Redo : ${isWinOS ? 'Ctrl + Y' : 'Cmd + Shift + Z'}`,
     onClick: () => {
       handleRedo()
     },

--- a/src/components/ToolBar/UndoRedoButton.vue
+++ b/src/components/ToolBar/UndoRedoButton.vue
@@ -6,22 +6,19 @@ import type { UndoRedoArray } from '@/types/index'
 const { handleUndo, handleRedo } = useStoreHistory()
 
 const ua = window.navigator.userAgent.toLowerCase()
+const isWinOS = ua.indexOf('windows nt') !== -1
 
 const undoRedoArray: UndoRedoArray[] = reactive([
   {
     icon: 'undo',
-    tooltip: `Undo : ${
-      ua.indexOf('windows nt') !== -1 ? 'Ctrl + Z' : 'Command + Z'
-    }`,
+    tooltip: `Undo : ${isWinOS ? 'Ctrl + Z' : 'Cmd + Z'}`,
     onClick: () => {
       handleUndo()
     },
   },
   {
     icon: 'redo',
-    tooltip: `Redo : ${
-      ua.indexOf('windows nt') !== -1 ? 'Ctrl + Y' : 'Command + Y'
-    }`,
+    tooltip: `Redo : ${isWinOS ? 'Ctrl + Y' : 'Cmd + Shift + Y'}`,
     onClick: () => {
       handleRedo()
     },

--- a/src/stores/konva/image.ts
+++ b/src/stores/konva/image.ts
@@ -129,8 +129,8 @@ const useStoreImage = defineStore({
             scaleY: 1,
           },
         ])
+        useStoreHistory().handleEventEndSaveHistory()
       }
-      useStoreHistory().handleEventEndSaveHistory()
 
       // モード終了し、サブメニューを閉じる
       useStoreMode().$reset()

--- a/src/stores/konva/transformer.ts
+++ b/src/stores/konva/transformer.ts
@@ -298,7 +298,7 @@ const useStoreTransformer = defineStore({
 
     // keydownで選択中の要素を削除
     async handleKeyDownSelectedNodeDelete(e: KeyboardEvent) {
-      if (e.key === 'Delete') {
+      if (e.key === 'Delete' || e.key === 'Backspace') {
         if (this.configShapeTransformer.nodes.length === 0) return
         const selectedNode = this.configShapeTransformer.nodes[0]
 

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -75,6 +75,7 @@ const {
 
 const { saveImageCountToFirebase } = useStoreUserImage()
 const { fitStageIntoParentContainer } = useStoreStage()
+const { handleRedo, handleUndo } = useStoreHistory()
 // useStore end
 
 const stageParentDiv = ref()
@@ -112,18 +113,26 @@ const blurInput = () => {
 const changeModeByShortCut = (e: KeyboardEvent) => {
   // テキスト編集中はショートカット無効
   if (isEditing.value || inputText.isEditing) return
-  if (e.key === 'p' || e.key === 'm') {
+  // pen
+  if (e.key === 'p') {
     setMode('pen')
     setGlobalCompositeOperation('source-over')
     useStoreTransformer().$reset()
-  } else if (e.shiftKey && e.key === 'Delete') {
+  }
+  // eraser
+  else if (e.shiftKey && e.key === 'Backspace') {
     setMode('eraser')
     setGlobalCompositeOperation('destination-out')
     useStoreTransformer().$reset()
-  } else if (e.key === 't') setMode('text')
+  }
+  // text
+  else if (e.key === 't') setMode('text')
+  // image
   else if (e.key === 'i') setMode('image')
   // undo
+  else if ((e.ctrlKey || e.metaKey) && e.key === 'z') handleUndo()
   // redo
+  else if ((e.ctrlKey || e.metaKey) && e.key === 'y') handleRedo()
 }
 
 // CreatePageに関わるstoreを初期化

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -149,7 +149,7 @@ const changeModeByShortCut = (e: KeyboardEvent) => {
   // redo
   else if (
     (isWinOS && e.ctrlKey && e.key === 'y') ||
-    ((isMacOS || isIPadOS) && e.metaKey && e.shiftKey && e.key === 'y')
+    ((isMacOS || isIPadOS) && e.metaKey && e.shiftKey && e.key === 'z')
   ) {
     handleRedo()
   }

--- a/src/views/CreatePage.vue
+++ b/src/views/CreatePage.vue
@@ -84,6 +84,12 @@ const transformer = ref()
 const canvasId = ref(useRoute().params.canvas_id as string)
 const router = useRouter()
 const saveState = ref<SaveState>('normal')
+const ua = window.navigator.userAgent.toLocaleLowerCase()
+const isWinOS = ua.indexOf('windows nt') !== -1
+const isMacOS = ua.indexOf('mac os x') !== -1
+const isIPadOS =
+  ua.indexOf('ipad') !== -1 ||
+  (ua.indexOf('macintosh') !== -1 && 'ontouchend' in document)
 // const selectionRectangle = ref()
 
 const showDoneBtn = () => {
@@ -130,9 +136,19 @@ const changeModeByShortCut = (e: KeyboardEvent) => {
   // image
   else if (e.key === 'i') setMode('image')
   // undo
-  else if ((e.ctrlKey || e.metaKey) && e.key === 'z') handleUndo()
+  else if (
+    (isWinOS && e.ctrlKey && e.key === 'z') ||
+    ((isMacOS || isIPadOS) && e.metaKey && e.key === 'z')
+  ) {
+    handleUndo()
+  }
   // redo
-  else if ((e.ctrlKey || e.metaKey) && e.key === 'y') handleRedo()
+  else if (
+    (isWinOS && e.ctrlKey && e.key === 'y') ||
+    ((isMacOS || isIPadOS) && e.metaKey && e.shiftKey && e.key === 'y')
+  ) {
+    handleRedo()
+  }
 }
 
 // CreatePageに関わるstoreを初期化


### PR DESCRIPTION
### 関連している Issue / 目的
#90 

### 達成条件
ショートカット機能の実装

### 実装の概要 / この PR の対応範囲
1. Undo Redoのショートカット実装
- Undo
　Windows　Ctrl + Z　Mac　Command + Z
- Redo
　Windows　Ctrl + Y　Mac　Command + Y

2. ToolTipの表示をOSによって切替え
3. 要素の削除をBackspaceキーまたはDeleteキーで行うようにした。


